### PR TITLE
Cronjob config map

### DIFF
--- a/standard-app/templates/configs/configmap.yaml
+++ b/standard-app/templates/configs/configmap.yaml
@@ -31,23 +31,16 @@
 {{- end }}
 
 # cronJob configMap
-{{- range $cronjobName, $cronjobConfig := .Values.cronjobs -}}
-  {{- if $cronjobConfig.volumes }}
-    {{- range $cronjobConfig.volumes }}
-      {{- if .type.configMap }}
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: {{ .type.configMap.name }}
-      data:
-        {{- range $key, $value := .configMapData }}
-          {{ $key }}: |- 
-            {{ tpl $value $ | nindent 4 }}
-        {{- end }}
-      {{- end }}
----
+{{- range $scriptName, $scriptConfig := .Values.scripts }}
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: {{ $scriptName }}
+  data:
+    {{- range $key, $value := $scriptConfig }}
+    {{ $key }}: |- 
+      {{ tpl $value $ }}
     {{- end }}
-  {{- end }}
 {{- end }}
 
 # job configMap

--- a/standard-app/templates/workloads/cronjob.yaml
+++ b/standard-app/templates/workloads/cronjob.yaml
@@ -68,12 +68,9 @@ spec:
                 {{- range $initContainer.args }}
                 - {{ . | quote -}}
                 {{ end }}
-              {{- if $cronjobConfig.volumes }}
+              {{- with $cronjobConfig.volumeMounts }}
               volumeMounts:
-                {{- range $cronjobConfig.volumes }}
-                - mountPath: {{ .mountPath }}
-                  name: {{ .name }}
-                {{- end }}
+                {{- toYaml . | nindent 16  }}
               {{- end }}
               env:
                 {{- range $key, $value := $initContainer.env }}
@@ -115,12 +112,9 @@ spec:
               resources:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
-              {{- if $cronjobConfig.volumes }}
+              {{- with $cronjobConfig.volumeMounts }}
               volumeMounts:
-                {{- range $cronjobConfig.volumes }}
-                - mountPath: {{ .mountPath }}
-                  name: {{ .name }}
-                {{- end }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
               env:
                 {{- range $key, $value := merge (default dict $cronjobConfig.env) (default dict $.Values.env) (default dict $container.env) }}
@@ -137,14 +131,9 @@ spec:
                     name: {{ $.Release.Name }}
                 {{- end }}
             {{- end }}
-          {{- if $cronjobConfig.volumes }}
+          {{- with $cronjobConfig.volumes }}
           volumes:
-            {{- range $cronjobConfig.volumes }}
-            - name: {{ .name }}
-              {{- with .type }}
-                {{- toYaml . | nindent 14 }}
-              {{- end }}
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           restartPolicy: {{ $cronjobConfig.restartPolicy | default "Never"}}
 ---

--- a/standard-app/templates/workloads/cronjob.yaml
+++ b/standard-app/templates/workloads/cronjob.yaml
@@ -68,9 +68,12 @@ spec:
                 {{- range $initContainer.args }}
                 - {{ . | quote -}}
                 {{ end }}
-              {{- with $cronjobConfig.volumeMounts }}
+              {{- if $cronjobConfig.volumes }}
               volumeMounts:
-                {{- toYaml . | nindent 16  }}
+                {{- range $cronjobConfig.volumes }}
+                - mountPath: {{ .mountPath }}
+                  name: {{ .name }}
+                {{- end }}
               {{- end }}
               env:
                 {{- range $key, $value := $initContainer.env }}
@@ -112,9 +115,12 @@ spec:
               resources:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
-              {{- with $cronjobConfig.volumeMounts }}
+              {{- if $cronjobConfig.volumes }}
               volumeMounts:
-                {{- toYaml . | nindent 16 }}
+                {{- range $cronjobConfig.volumes }}
+                - mountPath: {{ .mountPath }}
+                  name: {{ .name }}
+                {{- end }}
               {{- end }}
               env:
                 {{- range $key, $value := merge (default dict $cronjobConfig.env) (default dict $.Values.env) (default dict $container.env) }}
@@ -131,9 +137,14 @@ spec:
                     name: {{ $.Release.Name }}
                 {{- end }}
             {{- end }}
-          {{- with $cronjobConfig.volumes }}
+          {{- if $cronjobConfig.volumes }}
           volumes:
-            {{- toYaml . | nindent 12 }}
+            {{- range $cronjobConfig.volumes }}
+            - name: {{ .name }}
+              {{- with .type }}
+                {{- toYaml . | nindent 14 }}
+              {{- end }}
+            {{- end }}
           {{- end }}
           restartPolicy: {{ $cronjobConfig.restartPolicy | default "Never"}}
 ---


### PR DESCRIPTION
change: this change is going to help us create a configMap with the necessary data that it needs for that env, job, app, conJob. With configurations in the value file (the data here is just for a cronJob):
```
scripts:
    db-backups-scripts:
      postgres_backup.sh: '{{ .Files.Get "./scripts/postgres_backup.sh" | nindent 4 }}'
 ```
before: we thought the template for configMap could go through every cronjob, application, and job to check for a volume before it creates a cronJob, which was not working at some point, we can't have two volumes in two cronjobs and it will create the configMap corresponding to it. we got an error.
 
 
 But this change will just create every configMap that needs to be created under the script value -  we can even remove the   deployment and job template as well: https://github.com/cloudkite-io/helm-standard-library/blob/eee3b932edeaf85de7c89bceb2dbc13ddfb7edf4/standard-app/templates/configs/configmap.yaml#L15
 because this change will fix it all, by just specifying the configMap that you want created with the data under the script value in the values file.