### PR TITLE
Add secretKey and property to externalsecret values

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.1.0
+version: 0.2.0
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -42,8 +42,8 @@ apps:
         args:
           - /etc/scripts/script1.sh
         secrets:
-          - SOURCE_PROJECT_ID
-          - SOURCE_INSTANCE_ID
+          - secretKey: SOURCE_PROJECT_ID
+            property: SOURCE_PROJECT_ID
     image: us-central1-docker.pkg.dev/cloudkite-infra-ops/cloudkite-docker-images/app-1
     tag: tag-1
     imagePullPolicy: None
@@ -79,6 +79,11 @@ apps:
     env:
       ENV1: foo
       ENV2: bar
+    secrets:
+      - secretKey: appsettings.json
+        property: APPSETTINGS_JSON
+      - secretKey: SOURCE_PROJECT_ID
+        property: SOURCE_PROJECT_ID
 
   # cloudkite-app-2:
   #   serviceAccount: cloudkite
@@ -123,10 +128,11 @@ externalSecret:
   refreshInterval: 15s
 
 secrets:
-  - AWS_ACCESS_KEY_ID
-  - AWS_SECRET_ACCESS_KEY
-  - AWS_LOCATION
-  
+  - secretKey: AWS_ACCESS_KEY_ID
+    property: AWS_ACCESS_KEY_ID
+  - secretKey: AWS_SECRET_ACCESS_KEY
+    property: GLOBAL_SECRET_ACCESS_KEY
+
   # TODO: add AWS Secrets Manager
 
 cronjobs:
@@ -171,8 +177,9 @@ cronjobs:
         args:
           - /etc/scripts/script1.sh
         secrets:
-          - SOURCE_PROJECT_ID
-          - SOURCE_INSTANCE_ID
+          - secretKey: SOURCE_PROJECT_ID
+            property: SOURCE_PROJECT_ID
+
       exampleinitcontainer-2:
         image: asdasd
         args: 
@@ -189,5 +196,7 @@ cronjobs:
         command: ["/bin/sh", "-c"]
         args: ["node", "example_app.js"]
         secrets:
-          - MONGO_URL
-          - POSTGRES_URL
+          - secretKey: appsettings.json
+            property: APPSETTINGS_JSON
+          - secretKey: SOURCE_PROJECT_ID
+            property: SOURCE_PROJECT_ID

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -43,7 +43,6 @@ apps:
           - /etc/scripts/script1.sh
         secrets:
           - secretKey: SOURCE_PROJECT_ID
-            property: SOURCE_PROJECT_ID
     image: us-central1-docker.pkg.dev/cloudkite-infra-ops/cloudkite-docker-images/app-1
     tag: tag-1
     imagePullPolicy: None
@@ -83,7 +82,7 @@ apps:
       - secretKey: appsettings.json
         property: APPSETTINGS_JSON
       - secretKey: SOURCE_PROJECT_ID
-        property: SOURCE_PROJECT_ID
+
 
   # cloudkite-app-2:
   #   serviceAccount: cloudkite
@@ -129,9 +128,7 @@ externalSecret:
 
 secrets:
   - secretKey: AWS_ACCESS_KEY_ID
-    property: AWS_ACCESS_KEY_ID
   - secretKey: AWS_SECRET_ACCESS_KEY
-    property: GLOBAL_SECRET_ACCESS_KEY
 
   # TODO: add AWS Secrets Manager
 
@@ -178,7 +175,7 @@ cronjobs:
           - /etc/scripts/script1.sh
         secrets:
           - secretKey: SOURCE_PROJECT_ID
-            property: SOURCE_PROJECT_ID
+
 
       exampleinitcontainer-2:
         image: asdasd
@@ -199,4 +196,3 @@ cronjobs:
           - secretKey: appsettings.json
             property: APPSETTINGS_JSON
           - secretKey: SOURCE_PROJECT_ID
-            property: SOURCE_PROJECT_ID

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret.property }}
+      property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
   {{- end }}
 ---

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -66,7 +66,7 @@ spec:
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret.property }}
+      property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
   {{- end }}
 ---
@@ -102,7 +102,7 @@ spec:
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret.property }}
+      property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
   {{- end }}
 ---
@@ -140,7 +140,7 @@ spec:
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret.property }}
+      property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
   {{- end }}
 ---
@@ -177,7 +177,7 @@ spec:
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret.property }}
+      property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
   {{- end }}
 ---
@@ -213,7 +213,7 @@ spec:
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret.property }}
+      property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
   {{- end }}
 ---

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -22,14 +22,14 @@ spec:
     creationPolicy: Owner
   data:
   {{- range $secret := $appConfig.secrets }}
-  - secretKey: {{ $secret }}
+  - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret }}
+      property: {{ $secret.property }}
       {{- end }}
   {{- end }}
 ---
@@ -59,14 +59,14 @@ spec:
     creationPolicy: Owner
   data:
   {{- range $secret := $jobConfig.secrets }}
-  - secretKey: {{ $secret }}
+  - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret }}
+      property: {{ $secret.property }}
       {{- end }}
   {{- end }}
 ---
@@ -95,14 +95,14 @@ spec:
     creationPolicy: Owner
   data:
   {{- range $secret := .Values.secrets }}
-  - secretKey: {{ $secret }}
+  - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret }}
+      property: {{ $secret.property }}
       {{- end }}
   {{- end }}
 ---
@@ -133,14 +133,14 @@ spec:
     creationPolicy: Owner
   data:
   {{- range $secret := $initContainerConfig.secrets }}
-  - secretKey: {{ $secret }}
+  - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret }}
+      property: {{ $secret.property }}
       {{- end }}
   {{- end }}
 ---
@@ -170,14 +170,14 @@ spec:
     creationPolicy: Owner
   data:
   {{- range $secret := $containerConfig.secrets }}
-  - secretKey: {{ $secret }}
+  - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret }}
+      property: {{ $secret.property }}
       {{- end }}
   {{- end }}
 ---
@@ -206,14 +206,14 @@ spec:
     creationPolicy: Owner
   data:
   {{- range $secret := $cronjobConfig.secrets }}
-  - secretKey: {{ $secret }}
+  - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-      property: {{ $secret }}
+      property: {{ $secret.property }}
       {{- end }}
   {{- end }}
 ---


### PR DESCRIPTION
**Before**: SecretKey and Property took the same value. This is compatible for env variables where the `key` stored in secret backend equals the variable. For secrets like json files or keys that differs from variable value, it isn't compatible.
```
    secrets:
      - APPSETTINGS_JSON
```
```
piVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
.
.
spec:
  data:
  - remoteRef:
      property: APPSETTINGS_JSON
    secretKey: APPSETTINGS_JSON
 .
 .
```


Now
```
    secrets:
      - secretKey: appsettings.json
        property: APPSETTINGS_JSON
     - secretKey: AWS_ACCESS_KEY_ID
 
```
```
piVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
.
.
spec:
  data:
  - remoteRef:
      property: APPSETTINGS_JSON
    secretKey: appsettings.json
  - remoteRef:
      property: AWS_ACCESS_KEY_ID
    secretKey: AWS_ACCESS_KEY_ID
 .
 .
```
