### PR TITLE
Adjust configMap template for script data

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.3.0
+version: 0.4.0
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -177,7 +177,10 @@ cronjobs:
           configMap:
             name: db-backups-scripts
         configMapData:
-          test_script.sh: '{{ .Files.Get "scripts/test_script.sh" | nindent 4 }}'
+          test_script.sh: |
+            #!/bin/bash
+            DATE=$(date +%d_%m)
+    #'{{ .Files.Get "scripts/test_script.sh" | nindent 4 }}' we are currently working on making configMap script data workable from a repo that's not standard library, for now you can use it like this.
         
 
     initContainers:

--- a/standard-app/templates/configs/configmap.yaml
+++ b/standard-app/templates/configs/configmap.yaml
@@ -1,10 +1,10 @@
 # Default configMap
 {{- if .Values.configMap }}
-  apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: {{ .Release.Name }}-configmap
-  data:
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap
+data:
   {{- range $key, $value := .Values.configMap }}
     {{ $key }}: {{ $value }}
   {{- end }}
@@ -13,21 +13,22 @@
 
 # Deployment configMap
 {{- range $appName, $appConfig := .Values.apps -}}
-  {{- if $appConfig.volumes }}
-    {{- range $appConfig.volumes }}
-      {{- if .type.configMap }}
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: {{ $appName }}-configmap
-      data:
-        {{- range $key, $value := .configMapData }}
-          {{ $key }}: |- {{ tpl $value $ }}
-        {{- end }}
-      {{- end }}
----
-    {{- end }}
+{{- if $appConfig.volumes }}
+{{- range $appConfig.volumes }}
+{{- if .type.configMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $appName }}-configmap
+data:
+  {{- range $key, $value := .configMapData }}
+  {{ $key }}: | 
+    {{ $value | nindent 4 }}
   {{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
 {{- end }}
 
 # cronJob configMap
@@ -41,7 +42,8 @@ metadata:
   name: {{ .type.configMap.name }}
 data:
   {{- range $key, $value := .configMapData }}
-  {{ $key }}: > {{- tpl $value $ }}
+  {{ $key }}: | 
+    {{ $value | nindent 4 }}
   {{- end }}
 {{- end }}
 ---
@@ -51,19 +53,20 @@ data:
 
 # job configMap
 {{- range $jobName, $jobConfig := .Values.jobs -}}
-  {{- if $jobConfig.volumes }}
-    {{- range $jobConfig.volumes }}
-      {{- if .type.configMap }}
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: {{ .type.configMap.name }}
-      data:
-        {{- range $key, $value := .configMapData }}
-        {{ $key }}: |- {{ tpl $value $ }}
-        {{- end }}
-      {{- end }}
----
-    {{- end }}
+{{- if $jobConfig.volumes }}
+{{- range $jobConfig.volumes }}
+{{- if .type.configMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .type.configMap.name }}
+data:
+  {{- range $key, $value := .configMapData }}
+  {{ $key }}: | 
+    {{ $value | nindent 4 }}
   {{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This PR is to adjust configMap creation for `deployment` `cronjobs` and `jobs` regarding script data. More Adjustments would be made to allow us to use script files from other repos to generate configMap data with the standard library.
Using our example in the PR:
```
apps:
  nginx:
    volumes:
      - name: scripts
        type:
          configMap:
            name: daily-sitemap-gen-script
            defaultMode: 0777
        configMapData:
          run_daily_sitemap_gen.sh: |
            #!/bin/bash
            DATE=$(date +%d_%m)
```

configMap should look like this:
<img width="509" alt="Screenshot 2024-04-17 at 8 55 07 PM" src="https://github.com/cloudkite-io/helm-standard-library/assets/41240528/0fc2af15-c4b7-4395-b6cf-619d051a9219">
