### PR TITLE
set hpa version to v2

### DIFF
--- a/standard-app/templates/autoscaling/hpa.yaml
+++ b/standard-app/templates/autoscaling/hpa.yaml
@@ -1,6 +1,6 @@
 {{ range $appName, $appConfig := .Values.apps }}
 {{- if $appConfig.hpa }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ if $.Values.pr }}{{ $.Release.Name }}-{{ $appName | trimPrefix $.Release.Name | trimPrefix "-" }}{{ else }}{{ $appName }}{{ end }}


### PR DESCRIPTION
Default version for HPA is v2 starting from Kubernetes 1.27 https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#:~:text=kubectl%20now%20uses%20HorizontalPodAutoscaler%20v2%20by%20default.%20(%23114886%2C%20%40a7i)