### PR TITLE
adding additional parameters

### DIFF
--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -32,6 +32,9 @@ spec:
       key: {{ $.Release.Name | upper }}_{{ $secret }}
     {{- end }}
     {{- if eq $.Values.externalSecret.type "vault" }}
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
       property: {{ $secret.property | default $secret.secretKey }}
     {{- end }}
@@ -69,6 +72,9 @@ spec:
       key: {{ $.Release.Name | upper }}_{{ $secret }}
     {{- end }}
     {{- if eq $.Values.externalSecret.type "vault" }}
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
       property: {{ $secret.property | default $secret.secretKey }}
     {{- end }}
@@ -105,6 +111,9 @@ spec:
       key: {{ $.Release.Name | upper }}_{{ $secret }}
     {{- end }}
     {{- if eq $.Values.externalSecret.type "vault" }}
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
       property: {{ $secret.property | default $secret.secretKey }}
     {{- end }}
@@ -142,6 +151,9 @@ spec:
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
       property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
@@ -178,6 +190,9 @@ spec:
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
       property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
@@ -216,6 +231,9 @@ spec:
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
       property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
@@ -253,6 +271,9 @@ spec:
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
       property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}
@@ -289,6 +310,9 @@ spec:
       key: {{ $.Release.Name | upper }}_{{ $secret }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
       property: {{ $secret.property | default $secret.secretKey }}
       {{- end }}


### PR DESCRIPTION
Lack of these parameters cause kube-prometheus-stack external secrets stay in Out-of-sync state all the time.
![image](https://github.com/cloudkite-io/helm-standard-library/assets/77637319/e923c6e5-9126-4fca-9b3f-adc4d040abee)
