### PR TITLE
Add liveness probe to workloads

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.4.4
+version: 0.4.5
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -74,6 +74,17 @@ apps:
           initialDelaySeconds: 5
           periodSeconds: 10
           successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3001
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 5
         resources:
           limits:
             memory: 1Gi

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -138,6 +138,17 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+          {{- if $containerConfig.livenessProbe }}
+          livenessProbe:
+            {{- with $containerConfig.livenessProbe }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- else if $appConfig.livenessProbe }}
+          livenessProbe:
+            {{- with $appConfig.livenessProbe }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
           env:
             {{- range $key, $value := merge (default dict $containerConfig.env) (default dict $appConfig.env) (default dict $.Values.env) }}
             - name: {{ $key }}
@@ -207,6 +218,10 @@ spec:
           {{- end }}
           {{- with $appConfig.readinessProbe }}
           readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $appConfig.livenessProbe }}
+          livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:


### PR DESCRIPTION
- adds a livenessProbe map to the deployment template to allow configuring liveness probes
- adds an example to the `example.values.yaml`
