### PR TITLE
Fix format violation caused by concatenating map object and string

### DIFF
--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -29,7 +29,7 @@ spec:
   - secretKey: {{ $secret.secretKey }}
     remoteRef:
     {{- if eq $.Values.externalSecret.type "gcp" }}
-      key: {{ $.Release.Name | upper }}_{{ $secret }}
+      key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
     {{- end }}
     {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -66,7 +66,7 @@ spec:
   - secretKey: {{ $secret.secretKey }}
     remoteRef:
     {{- if eq $.Values.externalSecret.type "gcp" }}
-      key: {{ $.Release.Name | upper }}_{{ $secret }}
+      key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
     {{- end }}
     {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -102,7 +102,7 @@ spec:
   - secretKey: {{ $secret.secretKey }}
     remoteRef:
     {{- if eq $.Values.externalSecret.type "gcp" }}
-      key: {{ $.Release.Name | upper }}_{{ $secret }}
+      key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
     {{- end }}
     {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -139,7 +139,7 @@ spec:
   - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
-      key: {{ $.Release.Name | upper }}_{{ $secret }}
+      key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -175,7 +175,7 @@ spec:
   - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
-      key: {{ $.Release.Name | upper }}_{{ $secret }}
+      key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -213,7 +213,7 @@ spec:
   - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
-      key: {{ $.Release.Name | upper }}_{{ $secret }}
+      key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -250,7 +250,7 @@ spec:
   - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
-      key: {{ $.Release.Name | upper }}_{{ $secret }}
+      key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -286,7 +286,7 @@ spec:
   - secretKey: {{ $secret.secretKey }}
     remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
-      key: {{ $.Release.Name | upper }}_{{ $secret }}
+      key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
       {{- if eq $.Values.externalSecret.type "vault" }}
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}


### PR DESCRIPTION
This should fix this issue for GCP when using SecretManager.

```
 Warning  UpdateFailed  8m47s (x18 over 19m)  external-secrets  error retrieving secret at .data[0], key: GX-TRIAL-UPLOADS_map[secretKey:JWT_SECRET_KEY], err: unable to access Secret from SecretManager Client: rpc error: code = InvalidArgument desc = The provided Secret ID [projects/epicore-dev/secrets/GX-TRIAL-UPLOADS_map[secretKey:JWT_SECRET_KEY]/versions/latest] does not match the expected format [projects/*/secrets/*/versions/*]
 ```