### PR TITLE
replace extra ingresses with ingresses

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.7.0
+version: 0.8.0
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -46,7 +46,8 @@ ingress:  # NOTE: >0.8.0 DEPRECATES this, USE .Values.ingresses
 
 ingresses:
   cloudkite-app-1-webhook:
-    # ingressClass: set this to override the default ingress class in the cluster
+    # ingressClass: set this to override the ingress class used for the ingress (if not set, 
+    # the ingress will use the ingress class set as defualt in the cluster)
     ingressClass: nginx-external
     annotations:
       kubernetes.io/tls-acme: "true"

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -46,6 +46,7 @@ ingress:  # NOTE: >0.8.0 DEPRECATES this, USE .Values.ingresses
 
 ingresses:
   cloudkite-app-1-webhook:
+    # ingressClass: set this to override the default ingress class in the cluster
     ingressClass: nginx-external
     annotations:
       kubernetes.io/tls-acme: "true"
@@ -59,7 +60,6 @@ ingresses:
         serviceName: cloudkite-app-1
   # additional ingresses are optional
   cloudkite-app-2-webhook:
-    ingressClass: nginx-external
     annotations:
       kubernetes.io/tls-acme: "true"
       ingress.kubernetes.io/ssl-redirect: "true"

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -12,7 +12,7 @@ labels:
   label1: somevalue
   label2: anothervalue
 
-ingress:
+ingress:  # NOTE: DEPRECATED, USE .Values.ingresses
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -44,7 +44,7 @@ ingress:
       servicePort: 3003
       serviceName: cloudkite-app-2
 
-extraIngresses:
+ingresses:
   cloudkite-app-1-webhook:
     ingressClass: nginx-external
     annotations:
@@ -57,6 +57,18 @@ extraIngresses:
         pathType: Prefix
         servicePort: 5000
         serviceName: cloudkite-app-1
+  cloudkite-app-2-webhook:
+    ingressClass: nginx-external
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      ingress.kubernetes.io/ssl-redirect: "true"
+    hosts:
+      - test-callbacks.dev.someotherorg.com
+    paths:
+      - path: /webhook
+        pathType: Prefix
+        servicePort: 5000
+        serviceName: cloudkite-app-2
 
 env:
   GLOBAL_ENV1: value1
@@ -269,7 +281,7 @@ externalSecret:
   # refreshInterval: 15s
 
 secrets:
-  # data:
+  data:
   # Vault/GCP/AWS Example
   - secretKey: AWS_ACCESS_KEY_ID   # - secretKey: & property: atribute for secrets are applicable to version 0.2.0, version 0.1.0 uses the key id without artribut names e.g (- AWS_ACCESS_KEY_ID)
   - secretKey: AWS_SECRET_ACCESS_KEY

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -12,7 +12,7 @@ labels:
   label1: somevalue
   label2: anothervalue
 
-ingress:  # NOTE: DEPRECATED, USE .Values.ingresses
+ingress:  # NOTE: >0.8.0 DEPRECATES this, USE .Values.ingresses
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -57,6 +57,7 @@ ingresses:
         pathType: Prefix
         servicePort: 5000
         serviceName: cloudkite-app-1
+  # additional ingresses are optional
   cloudkite-app-2-webhook:
     ingressClass: nginx-external
     annotations:

--- a/standard-app/templates/network/ingress.yaml
+++ b/standard-app/templates/network/ingress.yaml
@@ -69,7 +69,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- with $ingConfig.ingressClass }}
   ingressClassName: {{ $ingConfig.ingressClass }}
+  {{- end }}
   tls:
   {{- if $ingConfig.tls }}
     {{- toYaml $ingConfig.tls | nindent 4 }}

--- a/standard-app/templates/network/ingress.yaml
+++ b/standard-app/templates/network/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress  }}
+{{- if .Values.ingress  }} # NOTE: >0.8.0 DEPRECATES this, USE .Values.ingresses
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/standard-app/templates/network/ingress.yaml
+++ b/standard-app/templates/network/ingress.yaml
@@ -58,8 +58,7 @@ spec:
 ---
 {{- end }}
 ---
-{{- range $ingName, $ingConfig := .Values.extraIngresses }}
----
+{{- range $ingName, $ingConfig := .Values.ingresses }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -97,3 +96,4 @@ spec:
           {{- end }}
   {{- end }}
 {{- end }}
+---


### PR DESCRIPTION
- allows list of ingresses,
  - `.Values.ingress` is now Deprecated and will be dropped in a future release