### PR TITLE
Refactor services configuration per app & reconfigure container ports

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.8.5
+version: 0.9.0
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -111,16 +111,20 @@ apps:
         #   maxReplicas: 12
         #   minReplicas: 3
         #   cpuTarget: 75
-        service:
-          name: tcp
-          type: ClusterIP
-          port: 5000
-          targetPort: 5000
-          protocol: TCP
+        ports:
+          - name: api-rest
+            containerPort: 5000
+            protocol: TCP
+          - name: api-grpc
+            containerPort: 5010
+            protocol: TCP
+          - name: api-metrics
+            containerPort: 5005
+            protocol: TCP
         readinessProbe:
           httpGet:
             path: /healthcheck
-            port: 3001
+            port: 5000
           initialDelaySeconds: 5
           periodSeconds: 10
           successThreshold: 1
@@ -129,7 +133,7 @@ apps:
         livenessProbe:
           httpGet:
             path: /healthcheck
-            port: 3001
+            port: 5000
           initialDelaySeconds: 5
           periodSeconds: 30
           successThreshold: 1
@@ -144,6 +148,75 @@ apps:
         env:
           CONTAINER_ENV1: asd
           CONTAINER_ENV2: qwe
+      example-container-2:
+        image: us-central1-docker.pkg.dev/cloudkite-infra-ops/cloudkite-docker-images/app-1
+        tag: tag-1
+        imagePullPolicy: None
+        ports:
+          - name: web
+            containerPort: 9000
+            protocol: TCP
+          - name: web-metrics
+            containerPort: 9005
+            protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 9000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 9000
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 300m
+            memory: 1Gi
+        env:
+          CONTAINER_ENV1: tyu
+          CONTAINER_ENV2: ghu
+    services:
+      - name: api
+        type: ClusterIP
+        externalPort: 5000
+        targetPort: 5000
+        protocol: TCP
+      - name: api-grpc
+        type: ClusterIP
+        externalPort: 5010
+        targetPort: api-grpc
+        protocol: TCP
+      - name: api-metrics
+        type: ClusterIP
+        externalPort: 5005
+        targetPort: 5005
+        protocol: TCP
+      - name: web
+        type: ClusterIP
+        externalPort: 9000
+        targetPort: web
+        protocol: TCP
+      - name: web-headless
+        type: None
+        externalPort: 9000
+        targetPort: web
+        protocol: TCP
+      - name: web-metrics
+        type: ClusterIP
+        externalPort: 9005
+        targetPort: web-metrics
+        protocol: TCP
     hpa:
       maxReplicas: 3
       minReplicas: 2
@@ -174,7 +247,8 @@ apps:
       runAsNonRoot: true
       runAsUser: 1000
       runAsGroup: 3000
-    
+  
+  example-app-1a:
     # Single structure for containers
     containers:
       container1:
@@ -203,12 +277,21 @@ apps:
       #   maxAllowed:
       #     memory: 4Gi
     # rollout: true
-    service:
-      name: tcp
-      type: ClusterIP
-      port: 3003
-      targetPort: 3003
-      protocol: TCP
+    ports:
+      - name: web
+        containerPort: 3003
+        protocol: TCP
+    services:
+      - name: web
+        type: ClusterIP
+        externalPort: 3003
+        targetPort: 3003
+        protocol: TCP
+      - name: web-headless
+        type: None
+        externalPort: 3003
+        targetPort: 3003
+        protocol: TCP
     resources:
       limits:
         memory: 1Gi

--- a/standard-app/templates/network/service.yaml
+++ b/standard-app/templates/network/service.yaml
@@ -1,14 +1,13 @@
 # deployment services
 {{ range $appName, $appConfig := .Values.apps }}
 
-# deployment container service
-{{- if $appConfig.containers }}
-{{- range $containerName, $containerConfig  := $appConfig.containers }}
-{{- if $containerConfig.service }}
+# deployment global services
+{{- if $appConfig.services }}
+{{- range $appConfig.services }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $containerName }}
+  name: {{ if $.Values.pr }}{{ $.Release.Name }}-{{ $appName | trimPrefix $.Release.Name | trimPrefix "-" }}{{ else }}{{ $appName }}-{{ .name }}{{ end }}
   labels:
     app: {{ if $.Values.pr }}{{ $.Release.Name }}-{{ $appName | trimPrefix $.Release.Name | trimPrefix "-" }}{{ else }}{{ $appName }}{{ end }}
     product: {{ $.Release.Name }}
@@ -16,39 +15,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ $containerConfig.service.type | default "ClusterIP" }}
+  type: {{ .type | default "ClusterIP" }}
   ports:
-    - port: {{ $containerConfig.service.port }}
-      name: {{ $containerConfig.service.name }}
-      targetPort: {{ $containerConfig.service.targetPort }}
-      protocol: {{ $containerConfig.service.protocol }}
+    - port: {{ .externalPort }}
+      name: {{ .name }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol }}
   selector:
     app: {{ if $.Values.pr }}{{ $.Release.Name }}-{{ $appName | trimPrefix $.Release.Name | trimPrefix "-" }}{{ else }}{{ $appName }}{{ end }}
 {{- end }}
----
-{{- end }}
-
-# deployment global service
-{{- else if $appConfig.service }}
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ if $.Values.pr }}{{ $.Release.Name }}-{{ $appName | trimPrefix $.Release.Name | trimPrefix "-" }}{{ else }}{{ $appName }}{{ end }}
-  labels:
-    app: {{ if $.Values.pr }}{{ $.Release.Name }}-{{ $appName | trimPrefix $.Release.Name | trimPrefix "-" }}{{ else }}{{ $appName }}{{ end }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  type: {{ $appConfig.service.type | default "ClusterIP" }}
-  ports:
-    - port: {{ $appConfig.service.port }}
-      name: {{ $appConfig.service.name }}
-      targetPort: {{ $appConfig.service.targetPort }}
-      protocol: {{ $appConfig.service.protocol }}
-  selector:
-    app: {{ if $.Values.pr }}{{ $.Release.Name }}-{{ $appName | trimPrefix $.Release.Name | trimPrefix "-" }}{{ else }}{{ $appName }}{{ end }}
 {{- end }}
 ---
 

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -126,16 +126,12 @@ spec:
             - {{ . | quote -}}
             {{ end }}
           {{ end }}
-          {{- if $containerConfig.service }}
+          {{- if $containerConfig.ports }}
           ports:
-            - name: {{ $containerConfig.service.name }}
-              containerPort: {{ $containerConfig.service.targetPort }}
-              protocol: {{ $containerConfig.service.protocol }}
-          {{- else if $appConfig.service }}
+            {{- toYaml $containerConfig.ports | nindent 12 }}
+          {{- else if $appConfig.ports }}
           ports:
-            - name: {{ $appConfig.service.name }}
-              containerPort: {{ $appConfig.service.targetPort }}
-              protocol: {{ $appConfig.service.protocol }}
+            {{- toYaml $appConfig.ports | nindent 12 }}
           {{- end }}
           {{- if $containerConfig.readinessProbe }}
           readinessProbe:
@@ -224,11 +220,9 @@ spec:
             - {{ . }}
             {{- end }}
           {{- end }}
-          {{- if $appConfig.service }}
+          {{- if $appConfig.ports }}
           ports:
-            - name: {{ $appConfig.service.name }}
-              containerPort: {{ $appConfig.service.targetPort }}
-              protocol: {{ $appConfig.service.protocol }}
+            {{- toYaml $appConfig.ports | nindent 12 }}
           {{- end }}
           {{- with $appConfig.readinessProbe }}
           readinessProbe:


### PR DESCRIPTION
**NOTE:** **BREAKING CHANGES**
Reconfigures the services and container templates:
- An app can have more than one service defined in a list at `apps.<id>.services`.
  - remove services configuration using list of containers.
- An app can have more than one service targeting one container with one or more than one ports
- A container in an app can have more than one port defined in a list at `apps.<id>.containers.<id>.ports` matched with `apps.<id>.services`
- An app with just one container can have ports defined at the top level at `apps.<id>.ports` matched with `apps.<id>.services`
- Allows better naming of ports and services