### PR TITLE
configure service values to have multiple ports

### DIFF
--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -189,34 +189,37 @@ apps:
     services:
       - name: api
         type: ClusterIP
-        externalPort: 5000
-        targetPort: 5000
-        protocol: TCP
-      - name: api-grpc
-        type: ClusterIP
-        externalPort: 5010
-        targetPort: api-grpc
-        protocol: TCP
-      - name: api-metrics
-        type: ClusterIP
-        externalPort: 5005
-        targetPort: 5005
-        protocol: TCP
+        ports:
+          - name: api-rest
+            port: 5000
+            targetPort: 5000
+            protocol: TCP
+          - name: api-grpc
+            port: 5010
+            targetPort: api-grpc
+            protocol: TCP
+          - name: metrics
+            port: 5005
+            targetPort: 5005
+            protocol: TCP
       - name: web
         type: ClusterIP
-        externalPort: 9000
-        targetPort: web
-        protocol: TCP
+        ports:
+          - name: web
+            port: 9000
+            targetPort: 9000
+            protocol: TCP
+          - name: metrics
+            port: 9005
+            targetPort: web-metrics
+            protocol: TCP
       - name: web-headless
         type: None
-        externalPort: 9000
-        targetPort: web
-        protocol: TCP
-      - name: web-metrics
-        type: ClusterIP
-        externalPort: 9005
-        targetPort: web-metrics
-        protocol: TCP
+        ports:
+          - name: web
+            port: 9000
+            targetPort: web
+            protocol: TCP
     hpa:
       maxReplicas: 3
       minReplicas: 2
@@ -281,17 +284,28 @@ apps:
       - name: web
         containerPort: 3003
         protocol: TCP
+      - name: metrics
+        containerPort: 3006
+        protocol: TCP
     services:
       - fullname: example-app-2
         type: ClusterIP
-        externalPort: 3003
-        targetPort: 3003
-        protocol: TCP
+        ports:
+          - name: web
+            port: 3003
+            targetPort: 3003
+            protocol: TCP
+          - name: metrics
+            port: 3006
+            targetPort: 3006
+            protocol: TCP
       - name: web-headless
         type: None
-        externalPort: 3003
-        targetPort: 3003
-        protocol: TCP
+        ports:
+          - name: web
+            port: 3003
+            targetPort: 3003
+            protocol: TCP
     resources:
       limits:
         memory: 1Gi

--- a/standard-app/templates/network/service.yaml
+++ b/standard-app/templates/network/service.yaml
@@ -17,10 +17,7 @@ metadata:
 spec:
   type: {{ .type | default "ClusterIP" }}
   ports:
-    - port: {{ .externalPort }}
-      name: {{ .name }}
-      targetPort: {{ .targetPort }}
-      protocol: {{ .protocol }}
+    {{- toYaml .ports | nindent 4 }}
   selector:
     app: {{ if $.Values.pr }}{{ $.Release.Name }}-{{ $appName | trimPrefix $.Release.Name | trimPrefix "-" }}{{ else }}{{ $appName }}{{ end }}
 ---


### PR DESCRIPTION
Allow services to have list of ports in `apps.<id>.services` so we can have something like
```yaml
apiVersion: v1
kind: Service
metadata:
  name: example-app-2
  labels:
    app: example-app-2
    product: standard-app
    label1: somevalue
    label2: anothervalue
spec:
  type: ClusterIP
  ports:
    - name: web
      port: 3003
      protocol: TCP
      targetPort: 3003
    - name: metrics
      port: 3006
      protocol: TCP
      targetPort: 3006
  selector:
    app: example-app-2
 ```


Building on https://github.com/cloudkite-io/helm-standard-library/pull/53