### PR TITLE
Add GateWay API to library and update example file

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.9.4
+version: 0.9.5
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -381,9 +381,6 @@ apps:
       - serviceName: example-app-2 # Name of the service to which the backend policy applies
         clientSecretName: example-app-2 # Name of the Kubernetes secret containing the OAuth2 client secret. SecretKey must be 'key' 
         clientID: 00000-xxxaaazzz.apps.googleusercontent.com
-      - serviceName: example-app-2-web-headless
-        clientSecretName: example-app-2
-        clientID: 00000-xxxaaazzz.apps.googleusercontent.com
 
   example-app-3:
     serviceAccount: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -90,6 +90,49 @@ serviceAccounts:
     annotations:
       iam.gke.io/gcp-service-account: GOOGLE_SERVICE_ACCOUNT_NAME@PROJECT_ID.iam.gserviceaccount.com
 
+
+gateways:
+  example-gateway:
+    enabled: true
+    annotations:
+      networking.gke.io/certmap: example-gateway-map # Optional, used for Google managed certificate, managed certificate and map can be created manually https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#create_a_certificate_map
+    gatewayClass: gke-l7-global-external-managed # Default to GKE L7 Global External Managed Gateway you can change this to internal gateway class
+    listeners:
+      - name: https
+        protocol: HTTPS
+        port: 443
+        # Optional, if not specified it defaults to allowing routes in the same namespace. For more permissive settings, you can specify the namespaces or labels: https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#create_a_certificate_map.
+        allowedRoutes: 
+          namespaces:
+            from: Same # Allow routes in the same namespace by default
+    # Optional, if you want to specify a specific external reserved or internal address for the Gateway, if left empty, the gateway will use the default address for the cluster based on the gateway class.
+    addresses:
+      - type: NamedAddress
+        value: example-ip-address-name # Name of external IP address
+    # Optional, if you want to specify labels for the allowed routes, this is useful for more fine-grained control over which routes are allowed to be used with this gateway. in this case the routes specified in the rules.
+    # allowedRoutesLabels:
+      # app: example-app
+      # environment: production
+    hostnames:
+      - api.dev.example.com
+      - api.example.com
+    rules:
+      - matches:
+        - path:
+            type: PathPrefix
+            value: /v1
+        backendRefs:
+        - name: example-app-2
+          port: 3003
+      - matches:
+        - path:
+            type: PathPrefix
+            value: /v2
+        backendRefs:
+        - name: example-app-2-web-headless
+          port: 3003
+
+
 apps:
   # you can specify init containers and containers for each deployment for a fine tuning (example-app-1), or use a simplified version in case you only need one container (example-app-2)
   # you can specify parameters on multiple levels: 
@@ -333,6 +376,14 @@ apps:
       capabilities:
         drop:
           - ALL
+    # GCP settings for the Gateway IAP backend policy
+    gatewayBackendPolicy:
+      - serviceName: example-app-2 # Name of the service to which the backend policy applies
+        clientSecretName: example-app-2 # Name of the Kubernetes secret containing the OAuth2 client secret. SecretKey must be 'key' 
+        clientID: 00000-xxxaaazzz.apps.googleusercontent.com
+      - serviceName: example-app-2-web-headless
+        clientSecretName: example-app-2
+        clientID: 00000-xxxaaazzz.apps.googleusercontent.com
 
   example-app-3:
     serviceAccount: cloudkite

--- a/standard-app/templates/network/gateway-iap-backend.yaml
+++ b/standard-app/templates/network/gateway-iap-backend.yaml
@@ -1,0 +1,22 @@
+{{ range $appName, $appConfig := .Values.apps }}
+{{- if $appConfig.gatewayBackendPolicy }}
+{{- range $appConfig.gatewayBackendPolicy }}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: {{ .serviceName }}-gateway-backend-policy
+spec:
+  default:
+    iap:
+      enabled: true
+      oauth2ClientSecret:
+        name: {{ .clientSecretName }}
+      clientID: {{ .clientID }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ .serviceName }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/standard-app/templates/network/gateway.yaml
+++ b/standard-app/templates/network/gateway.yaml
@@ -1,6 +1,6 @@
 {{- range $gatewayName, $gatewayConfig := .Values.gateways }}
 {{- if $gatewayConfig.enabled }}
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: {{ $gatewayName }}

--- a/standard-app/templates/network/gateway.yaml
+++ b/standard-app/templates/network/gateway.yaml
@@ -1,0 +1,36 @@
+{{- range $gatewayName, $gatewayConfig := .Values.gateways }}
+{{- if $gatewayConfig.enabled }}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}
+  {{- with $gatewayConfig.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ default "gke-l7-global-external-managed" $gatewayConfig.gatewayClass }}
+  listeners:
+  {{- range $gatewayConfig.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+{{ toYaml .allowedRoutes | indent 8 }}
+      {{- else }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+      {{- end }}
+  {{- end }}
+  {{- if $gatewayConfig.addresses }}
+  addresses:
+{{ toYaml $gatewayConfig.addresses | indent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/standard-app/templates/network/http-routes.yaml
+++ b/standard-app/templates/network/http-routes.yaml
@@ -1,5 +1,5 @@
 {{- range $gateWayName, $gateWayConfig := .Values.gateways }}
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $gateWayName }}-http-routes

--- a/standard-app/templates/network/http-routes.yaml
+++ b/standard-app/templates/network/http-routes.yaml
@@ -1,0 +1,30 @@
+{{- range $gateWayName, $gateWayConfig := .Values.gateways }}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: {{ $gateWayName }}-http-routes
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}
+  {{- with $gateWayConfig.allowedRoutesLabels }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: {{ $gateWayName }}
+      {{- if $gateWayConfig.namespace }}
+      namespace: {{ $gateWayConfig.namespace }}
+      {{- end }}
+  {{- with $gateWayConfig.hostnames }}
+  hostnames:
+  {{- range . }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- with $gateWayConfig.rules }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+---
+{{- end }}


### PR DESCRIPTION
This PR:
- Add Gateway API to the standard library
- Update example YAML
> PS: Aside from the IAP Backend Policy, the Gateway API should be the same for other cloud environment clusters when enabled.