### PR TITLE
remove data entry from the secrets

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.9.6
+version: 0.9.7
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -147,8 +147,7 @@ apps:
         args:
           - /etc/scripts/script1.sh
         secrets:
-          dataFrom:
-            version: version-number
+          dataFrom: true
     containers:
       example-container-1:
         image: us-central1-docker.pkg.dev/cloudkite-infra-ops/cloudkite-docker-images/app-1
@@ -481,8 +480,7 @@ secrets:
   # Azure Example
   # Serilog__WriteTo__0__Args__connectionString: SERILOG_CONNECTION_STRING
   # TokenConfig__Secret: TOKEN_CONFIG_SECRET
-  # dataFrom:
-  #   version: version-number
+  # dataFrom: true
 
 jobs:
   jobexample-1:
@@ -582,11 +580,7 @@ cronjobs:
         args:
           - /etc/scripts/script1.sh
         secrets:
-          data:
-            - secretKey: SOURCE_PROJECT_ID
-          dataFrom:
-            version: version-number
-
+            - SOURCE_PROJECT_ID
 
       exampleinitcontainer-2:
         image: asdasd
@@ -604,9 +598,6 @@ cronjobs:
         command: ["/bin/sh", "-c"]
         args: ["node", "example_app.js"]
         secrets:
-          data:
-            - secretKey: appsettings.json
-              property: APPSETTINGS_JSON
-            - secretKey: SOURCE_PROJECT_ID
-          dataFrom:
-            version: version-number
+          - secretKey: appsettings.json
+            property: APPSETTINGS_JSON
+          - secretKey: SOURCE_PROJECT_ID

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -147,7 +147,7 @@ apps:
         args:
           - /etc/scripts/script1.sh
         secrets:
-          secretsFrom:
+          dataFrom:
             version: version-number
     containers:
       example-container-1:

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -147,9 +147,7 @@ apps:
         args:
           - /etc/scripts/script1.sh
         secrets:
-          data:
-            - secretKey: SOURCE_PROJECT_ID
-          dataFrom:
+          secretsFrom:
             version: version-number
     containers:
       example-container-1:
@@ -280,12 +278,9 @@ apps:
       APP_ENV1: foo
       APP_ENV2: bar
     secrets:
-      data:
         - secretKey: appsettings.json
           property: APPSETTINGS_JSON
         - secretKey: SOURCE_PROJECT_ID
-      dataFrom:
-        version: version-number
     serviceMonitor:
       path: /metrics # default /metrics
       interval: 60s # default 30s
@@ -480,7 +475,6 @@ externalSecret:
   # refreshInterval: 15s
 
 secrets:
-  data:
   # Vault/GCP/AWS Example
   - secretKey: AWS_ACCESS_KEY_ID   # - secretKey: & property: atribute for secrets are applicable to version 0.2.0, version 0.1.0 uses the key id without artribut names e.g (- AWS_ACCESS_KEY_ID)
   - secretKey: AWS_SECRET_ACCESS_KEY

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -25,26 +25,26 @@ spec:
     name: {{ $initContainerName }}
     creationPolicy: Owner
   {{- if kindIs "map" $initContainerConfig.secrets }}
-  {{- if $initContainerConfig.secrets.data }}
+  {{- if $initContainerConfig.secretsFrom }}
+  dataFrom:
+    - extract:
+        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
+  {{- else }}
   data:
   {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $initContainerConfig.secrets.data  }}
+    {{- range $key, $value := $initContainerConfig.secrets  }}
     - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
     {{- end }}
   {{- else }}
-    {{- range $secret := $initContainerConfig.secrets.data }}
+    {{- range $secret := $initContainerConfig.secrets }}
     - secretKey: {{ $secret.secretKey }}
       remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
         key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
-      {{- if eq $.Values.externalSecret.type "vault" }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-      {{- if eq $.Values.externalSecret.type "aws" }}
+      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
         {{- if $.Values.externalSecret.secretPath }}
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
         {{- else }}
@@ -54,11 +54,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if $initContainerConfig.secrets.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
   {{- end }}
   {{- end }}
   {{- if kindIs "slice" $initContainerConfig.secrets }}
@@ -100,26 +95,26 @@ spec:
     name: {{ $containerName }}
     creationPolicy: Owner
   {{- if kindIs "map" $containerConfig.secrets }}
-  {{- if $containerConfig.secrets.data }}
+  {{- if $containerConfig.secretsFrom }}
+  dataFrom:
+    - extract:
+        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
+  {{- else }}
   data:
   {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $containerConfig.secrets.data  }}
+    {{- range $key, $value := $containerConfig.secrets  }}
     - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
     {{- end }}
   {{- else }}
-    {{- range $secret := $containerConfig.secrets.data }}
+    {{- range $secret := $containerConfig.secrets }}
     - secretKey: {{ $secret.secretKey }}
       remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
         key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
-      {{- if eq $.Values.externalSecret.type "vault" }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-      {{- if eq $.Values.externalSecret.type "aws" }}
+      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
         {{- if $.Values.externalSecret.secretPath }}
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
         {{- else }}
@@ -129,11 +124,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if $containerConfig.secrets.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
   {{- end }}
   {{- end }}
   {{- if kindIs "slice" $containerConfig.secrets }}
@@ -174,26 +164,26 @@ spec:
     name: {{ $appName }}
     creationPolicy: Owner
   {{- if kindIs "map" $appConfig.secrets }}
-  {{- if $appConfig.secrets.data }}
+  {{- if $appConfig.secretsFrom }}
+  dataFrom:
+    - extract:
+        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
+  {{- else }}
   data:
   {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $appConfig.secrets.data }}
+    {{- range $key, $value := $appConfig.secrets }}
     - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
     {{- end }}
   {{- else }}
-    {{- range $secret := $appConfig.secrets.data }}
+    {{- range $secret := $appConfig.secrets }}
     - secretKey: {{ $secret.secretKey }}
       remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
         key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
-      {{- if eq $.Values.externalSecret.type "vault" }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-      {{- if eq $.Values.externalSecret.type "aws" }}
+      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
         {{- if $.Values.externalSecret.secretPath }}
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
         {{- else }}
@@ -203,11 +193,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if $appConfig.secrets.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
   {{- end }}
   {{- end }}
   {{- if kindIs "slice" $appConfig.secrets }}
@@ -250,26 +235,26 @@ spec:
     name: {{ $jobName }}
     creationPolicy: Owner
   {{- if kindIs "map" $jobConfig.secrets }}
-  {{- if $jobConfig.secrets.data }}
+    {{- if $jobConfig.secretsFrom }}
+  dataFrom:
+  - extract:
+      key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
+  {{- else }}
   data:
   {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $jobConfig.secrets.data  }}
+    {{- range $key, $value := $jobConfig.secrets  }}
     - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
     {{- end }}
   {{- else }}
-    {{- range $secret := $jobConfig.secrets.data }}
+    {{- range $secret := $jobConfig.secrets }}
     - secretKey: {{ $secret.secretKey }}
       remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
         key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
-      {{- if eq $.Values.externalSecret.type "vault" }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-      {{- if eq $.Values.externalSecret.type "aws" }}
+      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
         {{- if $.Values.externalSecret.secretPath }}
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
         {{- else }}
@@ -279,11 +264,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if $jobConfig.secrets.dataFrom }}
-  dataFrom:
-  - extract:
-      key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
   {{- end }}
   {{- end }}
   {{- if kindIs "slice" $jobConfig.secrets }}
@@ -324,26 +304,26 @@ spec:
     name: {{ .Release.Name }}
     creationPolicy: Owner
   {{- if kindIs "map" .Values.secrets }}
-  {{- if .Values.secrets.data }}
+  {{- if .Values.secretsFrom }}
+  dataFrom:
+    - extract:
+        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
+  {{- else }}
   data:
   {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := .Values.secrets.data  }}
+    {{- range $key, $value := .Values.secrets  }}
     - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
     {{- end }}
   {{- else }}
-    {{- range $secret := .Values.secrets.data }}
+    {{- range $secret := .Values.secrets }}
     - secretKey: {{ $secret.secretKey }}
       remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
         key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
-      {{- if eq $.Values.externalSecret.type "vault" }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-      {{- if eq $.Values.externalSecret.type "aws" }}
+      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
         {{- if $.Values.externalSecret.secretPath }}
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
         {{- else }}
@@ -353,11 +333,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if .Values.secrets.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
   {{- end }}
   {{- end }}
   {{- if kindIs "slice" .Values.secrets }}
@@ -400,26 +375,26 @@ spec:
     name: {{ $initContainerName }}
     creationPolicy: Owner
   {{- if kindIs "map" $initContainerConfig.secrets }}
-  {{- if $initContainerConfig.secrets.data }}
+  {{- if $initContainerConfig.secretsFrom }}
+  dataFrom:
+    - extract:
+        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
+  {{- else }}
   data:
   {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $initContainerConfig.secrets.data }}
+    {{- range $key, $value := $initContainerConfig.secrets }}
     - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
     {{- end }}
   {{- else }}
-    {{- range $secret := $initContainerConfig.secrets.data }}
+    {{- range $secret := $initContainerConfig.secrets }}
     - secretKey: {{ $secret.secretKey }}
       remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
         key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
-      {{- if eq $.Values.externalSecret.type "vault" }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-      {{- if eq $.Values.externalSecret.type "aws" }}
+      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
         {{- if $.Values.externalSecret.secretPath }}
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
         {{- else }}
@@ -429,11 +404,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if $initContainerConfig.secrets.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
   {{- end }}
   {{- end }}
   {{- if kindIs "slice" $initContainerConfig.secrets }}
@@ -475,26 +445,26 @@ spec:
     name: {{ $containerName }}
     creationPolicy: Owner
   {{- if kindIs "map" $containerConfig.secrets }}
-  {{- if $containerConfig.secrets.data }}
+  {{- if $containerConfig.secretsFrom }}
+  dataFrom:
+    - extract:
+        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
+  {{- else }}
   data:
   {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $containerConfig.secrets.data }}
+    {{- range $key, $value := $containerConfig.secrets }}
     - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
     {{- end }}
   {{- else }}
-    {{- range $secret := $containerConfig.secrets.data }}
+    {{- range $secret := $containerConfig.secrets }}
     - secretKey: {{ $secret.secretKey }}
       remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
         key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
-      {{- if eq $.Values.externalSecret.type "vault" }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-      {{- if eq $.Values.externalSecret.type "aws" }}
+      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
         {{- if $.Values.externalSecret.secretPath }}
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
         {{- else }}
@@ -504,11 +474,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if $containerConfig.secrets.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
   {{- end }}
   {{- end }}
   {{- if kindIs "slice" $containerConfig.secrets }}
@@ -549,26 +514,26 @@ spec:
     name: {{ $cronjobName }}
     creationPolicy: Owner
   {{- if kindIs "map" $cronjobConfig.secrets }}
-  {{- if $cronjobConfig.secrets.data }}
+  {{- if $cronjobConfig.secretsFrom }}
+  dataFrom:
+    - extract:
+        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
+  {{- else }}
   data:
   {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $cronjobConfig.secrets.data }}
+    {{- range $key, $value := $cronjobConfig.secrets }}
     - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
     {{- end }}
   {{- else }}
-    {{- range $secret := $cronjobConfig.secrets.data }}
+    {{- range $secret := $cronjobConfig.secrets }}
     - secretKey: {{ $secret.secretKey }}
       remoteRef:
       {{- if eq $.Values.externalSecret.type "gcp" }}
         key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
       {{- end }}
-      {{- if eq $.Values.externalSecret.type "vault" }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-      {{- if eq $.Values.externalSecret.type "aws" }}
+      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
         {{- if $.Values.externalSecret.secretPath }}
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
         {{- else }}
@@ -578,11 +543,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if $cronjobConfig.secrets.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
   {{- end }}
   {{- end }}
   {{- if kindIs "slice" $cronjobConfig.secrets }}

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -25,7 +25,7 @@ spec:
     name: {{ $initContainerName }}
     creationPolicy: Owner
   {{- if kindIs "map" $initContainerConfig.secrets }}
-  {{- if $initContainerConfig.secretsFrom }}
+  {{- if $initContainerConfig.dataFrom }}
   dataFrom:
     - extract:
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -95,7 +95,7 @@ spec:
     name: {{ $containerName }}
     creationPolicy: Owner
   {{- if kindIs "map" $containerConfig.secrets }}
-  {{- if $containerConfig.secretsFrom }}
+  {{- if $containerConfig.dataFrom }}
   dataFrom:
     - extract:
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -164,7 +164,7 @@ spec:
     name: {{ $appName }}
     creationPolicy: Owner
   {{- if kindIs "map" $appConfig.secrets }}
-  {{- if $appConfig.secretsFrom }}
+  {{- if $appConfig.dataFrom }}
   dataFrom:
     - extract:
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -235,7 +235,7 @@ spec:
     name: {{ $jobName }}
     creationPolicy: Owner
   {{- if kindIs "map" $jobConfig.secrets }}
-    {{- if $jobConfig.secretsFrom }}
+    {{- if $jobConfig.dataFrom }}
   dataFrom:
   - extract:
       key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -304,7 +304,7 @@ spec:
     name: {{ .Release.Name }}
     creationPolicy: Owner
   {{- if kindIs "map" .Values.secrets }}
-  {{- if .Values.secretsFrom }}
+  {{- if .Values.dataFrom }}
   dataFrom:
     - extract:
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -375,7 +375,7 @@ spec:
     name: {{ $initContainerName }}
     creationPolicy: Owner
   {{- if kindIs "map" $initContainerConfig.secrets }}
-  {{- if $initContainerConfig.secretsFrom }}
+  {{- if $initContainerConfig.dataFrom }}
   dataFrom:
     - extract:
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -445,7 +445,7 @@ spec:
     name: {{ $containerName }}
     creationPolicy: Owner
   {{- if kindIs "map" $containerConfig.secrets }}
-  {{- if $containerConfig.secretsFrom }}
+  {{- if $containerConfig.dataFrom }}
   dataFrom:
     - extract:
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
@@ -514,7 +514,7 @@ spec:
     name: {{ $cronjobName }}
     creationPolicy: Owner
   {{- if kindIs "map" $cronjobConfig.secrets }}
-  {{- if $cronjobConfig.secretsFrom }}
+  {{- if $cronjobConfig.dataFrom }}
   dataFrom:
     - extract:
         key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}


### PR DESCRIPTION
1. remove the need to specify `data` in `secrets` map
The following format is not supported anymore:
```
secrets:
  data:
```

2. Move `dataFrom` block on the top of the conditional that checks if secrets are of a `map` kind
3. Merge `vault` and `aws` conditionals into one as they were about the same