### PR TITLE
add gke load balancer healthchek

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.9.8
+version: 0.9.9
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -601,3 +601,7 @@ cronjobs:
           - secretKey: appsettings.json
             property: APPSETTINGS_JSON
           - secretKey: SOURCE_PROJECT_ID
+healthCheckPolicy:
+  port: 80 # Optional, defaults to 80
+  requestPath: / # Optional, defaults to /
+  targetServiceName: api-documentation-tcp # Required, the name of the service to which the health check policy applies. Should correspond to HttpRoute service name.

--- a/standard-app/templates/network/db-healthcheck.yaml
+++ b/standard-app/templates/network/db-healthcheck.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.healthCheckPolicy }}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ .Release.Name }}-lb-healthcheck
+  namespace: {{ .Release.Namespace }}
+spec:
+  default:
+    checkIntervalSec: 5
+    timeoutSec: 3
+    healthyThreshold: 1
+    unhealthyThreshold: 5
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: {{ .Values.healthCheckPolicy.port | default 80 }}
+        requestPath: {{ .Values.healthCheckPolicy.requestPath | default "/" }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ .Values.healthCheckPolicy.targetServiceName }}
+{{- end }}


### PR DESCRIPTION
- this is neccessary when using another path or headers that the default one doesn't use.