### PR TITLE
Encapsulate common chart elements into templates

### DIFF
--- a/.github/workflows/standard-app-publish.yaml
+++ b/.github/workflows/standard-app-publish.yaml
@@ -9,7 +9,7 @@ env:
 
 on:
   release:
-    types: [published]
+    types: [created]
   
 jobs:
   publish:

--- a/.github/workflows/standard-app-publish.yaml
+++ b/.github/workflows/standard-app-publish.yaml
@@ -8,11 +8,8 @@ env:
   REPOSITORY: public-helm-charts
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [main]
-    paths: [standard-app/**]
-
+  release
+  
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/standard-app-publish.yaml
+++ b/.github/workflows/standard-app-publish.yaml
@@ -8,7 +8,8 @@ env:
   REPOSITORY: public-helm-charts
 
 on:
-  release
+  release:
+    types: [published]
   
 jobs:
   publish:

--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.11.0
+version: 1.0.0
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 0.10.1
+version: 0.11.0
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -279,9 +279,9 @@ apps:
       APP_ENV1: foo
       APP_ENV2: bar
     secrets:
-        - secretKey: appsettings.json
-          property: APPSETTINGS_JSON
-        - secretKey: SOURCE_PROJECT_ID
+      - secretKey: appsettings.json
+        property: APPSETTINGS_JSON
+      - secretKey: SOURCE_PROJECT_ID
     serviceMonitor:
       path: /metrics # default /metrics
       interval: 60s # default 30s
@@ -461,15 +461,15 @@ externalSecret:
   # secretPath: example-path
 
   ## AWS secrets manager
-  # secretStoreName: example-name
-  # type: aws
-  # refreshInterval: 1m
+  secretStoreName: example-name
+  type: aws
+  refreshInterval: 1m
   # secretPath: example-path
 
   # Google Secret Manager
-  secretStoreName: example-name
-  type: gcp
-  refreshInterval: 15s
+  # secretStoreName: example-name
+  # type: gcp
+  # refreshInterval: 15s
 
   # Azure Key Vault
   # secretStoreName: example-name
@@ -483,7 +483,9 @@ secrets:
   # Azure Example
   # Serilog__WriteTo__0__Args__connectionString: SERILOG_CONNECTION_STRING
   # TokenConfig__Secret: TOKEN_CONFIG_SECRET
-  # dataFrom: true
+  # dataFrom:
+    # - secret-1
+    # - secret/two
 
 jobs:
   jobexample-1:
@@ -583,7 +585,9 @@ cronjobs:
         args:
           - /etc/scripts/script1.sh
         secrets:
-            - SOURCE_PROJECT_ID
+          dataFrom:
+            - data-from-secret-1
+            - data/from/secret/two
 
       exampleinitcontainer-2:
         image: asdasd

--- a/standard-app/templates/_labels.tpl
+++ b/standard-app/templates/_labels.tpl
@@ -1,0 +1,5 @@
+{{- define "standard-app.labels" -}}
+{{- $defaultLabels := dict "app" .component "product" .Release.Name -}}
+labels:
+{{- toYaml (merge $defaultLabels (default dict .labels)) | nindent 2 }}
+{{- end }}

--- a/standard-app/templates/autoscaling/hpa.yaml
+++ b/standard-app/templates/autoscaling/hpa.yaml
@@ -1,15 +1,16 @@
 {{ range $appName, $appConfig := .Values.apps }}
+{{- $appValues := dict
+      "component" $appName
+      "Values"    $.Values
+      "Release"   $.Release
+      "labels"    (default (dict) $.Values.labels)
+    -}}
 {{- if $appConfig.hpa }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $appName }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   maxReplicas: {{ $appConfig.hpa.maxReplicas }}
   minReplicas: {{ $appConfig.hpa.minReplicas }}

--- a/standard-app/templates/autoscaling/mpa.yaml
+++ b/standard-app/templates/autoscaling/mpa.yaml
@@ -1,15 +1,16 @@
 {{ range $appName, $appConfig := .Values.apps }}
+{{- $appValues := dict
+      "component" $appName
+      "Values"    $.Values
+      "Release"   $.Release
+      "labels"    (default (dict) $.Values.labels)
+    -}}
 {{- if $appConfig.mpa }}
 apiVersion: autoscaling.gke.io/v1beta1
 kind: MultidimPodAutoscaler
 metadata:
   name: {{ $appName }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   scaleTargetRef:
     apiVersion: {{ if $appConfig.rollout }}argoproj.io/v1alpha1{{ else }}apps/v1{{ end }}

--- a/standard-app/templates/autoscaling/vpa.yaml
+++ b/standard-app/templates/autoscaling/vpa.yaml
@@ -1,15 +1,16 @@
 {{ range $appName, $appConfig := .Values.apps }}
+{{- $appValues := dict
+      "component" $appName
+      "Values"    $.Values
+      "Release"   $.Release
+      "labels"    (default (dict) $.Values.labels)
+    -}}
 {{- if $appConfig.vpa }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ $appName }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   targetRef:
     apiVersion: {{ if $appConfig.rollout }}argoproj.io/v1alpha1{{ else }}apps/v1{{ end }}

--- a/standard-app/templates/autoscaling/vpa.yaml
+++ b/standard-app/templates/autoscaling/vpa.yaml
@@ -17,7 +17,7 @@ spec:
     kind:       {{ if $appConfig.rollout }}Rollout{{ else }}Deployment{{ end }}
     name:       {{ $appName }}
   updatePolicy:
-    updateMode: "Off"
+    updateMode: {{ $appConfig.vpa.mode | default "Off" }}
   {{- with $appConfig.vpa.resources }}
   resourcePolicy:
     containerPolicies:

--- a/standard-app/templates/configs/_configmap.tpl
+++ b/standard-app/templates/configs/_configmap.tpl
@@ -1,0 +1,11 @@
+{{- define "standard-app.configMap" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+data:
+  {{- range $key, $value := .data }}
+  {{ $key }}: |-
+    {{ $value | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -29,22 +29,22 @@ spec:
   data:
       {{- if eq $type "azure" }}
         {{- range $key, $value := $secrets.data }}
-    - secretKey: {{ $key }}
+    - secretKey: {{ $key | quote }}
       remoteRef:
-        key: {{ $value }}
+        key: {{ $value | quote }}
         {{- end }}
       {{- else }}
         {{- range $secret := $secrets.data }}
-    - secretKey: {{ $secret.secretKey }}
+    - secretKey: {{ $secret.secretKey | quote }}
       remoteRef:
         {{- if eq $type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
+        key: {{ printf "%s_%s" ($.Release.Name | upper) $secret.secretKey | quote }}
         {{- else if eq $type "vault" }}
-        key: {{ $secretPath }}/{{ $.Release.Name }}
-        property: {{ $secret.property | default $secret.secretKey }}
+        key: {{ printf "%s/%s" $secretPath $.Release.Name | quote }}
+        property: {{ ( $secret.property | default $secret.secretKey ) | quote }}
         {{- else if eq $type "aws" }}
-        key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
-        property: {{ $secret.property | default $secret.secretKey }}
+        key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") | quote }}
+        property: {{ ( $secret.property | default $secret.secretKey ) | quote }}
         {{- end }}
         {{- end }}
       {{- end }}
@@ -52,15 +52,15 @@ spec:
     {{- if and (hasKey $secrets "dataFrom") (not (empty $secrets.dataFrom)) }}
   dataFrom:
     - extract:
-        key: {{ $secretPath }}/{{ $.Release.Name }}
+        key: {{ printf "%s/%s" $secretPath $.Release.Name | quote }}
     {{- end }}
   {{- else if kindIs "slice" $secrets }}
   data:
     {{- range $secret := $secrets }}
-    - secretKey: {{ $secret }}
+    - secretKey: {{ $secret | quote }}
       remoteRef:
-        key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
-        property: {{ $secret }}
+        key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") | quote }}
+        property: {{ $secret | quote }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -59,8 +59,13 @@ spec:
       {{- else }}
     - secretKey: {{ $secret }}
       remoteRef:
+        {{- if eq $type "gcp" }}
+        key: {{ printf "%s_%s" ($.Release.Name | upper) $secret }}
+        property: {{ $secret }}
+        {{- else }}
         key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
         property: {{ $secret }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -1,0 +1,66 @@
+{{- define "standard-app.externalSecret" -}}
+{{- $name := .name }}
+{{- $userLabels := .labels | default dict }}
+{{- $globalLabels := $.Values.labels | default dict }}
+{{- $defaultLabels := dict "product" $.Release.Name }}
+{{- $labels := merge $defaultLabels $globalLabels $userLabels }}
+{{- $secrets := .secrets }}
+{{- $type := .type }}
+{{- $storeName := .storeName }}
+{{- $secretPath := .secretPath }}
+{{- $refreshInterval := .refreshInterval | default "1m" }}
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- toYaml $labels | nindent 4 }}
+spec:
+  refreshInterval: {{ $refreshInterval }}
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ $storeName }}
+  target:
+    name: {{ $name }}
+    creationPolicy: Owner
+  {{- if kindIs "map" $secrets }}
+    {{- if $secrets.data }}
+  data:
+      {{- if eq $type "azure" }}
+        {{- range $key, $value := $secrets.data }}
+    - secretKey: {{ $key }}
+      remoteRef:
+        key: {{ $value }}
+        {{- end }}
+      {{- else }}
+        {{- range $secret := $secrets.data }}
+    - secretKey: {{ $secret.secretKey }}
+      remoteRef:
+        {{- if eq $type "gcp" }}
+        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
+        {{- else if eq $type "vault" }}
+        key: {{ $secretPath }}/{{ $.Release.Name }}
+        property: {{ $secret.property | default $secret.secretKey }}
+        {{- else if eq $type "aws" }}
+        key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
+        property: {{ $secret.property | default $secret.secretKey }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if and (hasKey $secrets "dataFrom") (not (empty $secrets.dataFrom)) }}
+  dataFrom:
+    - extract:
+        key: {{ $secretPath }}/{{ $.Release.Name }}
+    {{- end }}
+  {{- else if kindIs "slice" $secrets }}
+  data:
+    {{- range $secret := $secrets }}
+    - secretKey: {{ $secret }}
+      remoteRef:
+        key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
+        property: {{ $secret }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -45,7 +45,7 @@ spec:
       remoteRef:
         {{- if eq $type "gcp" }}
         key: {{ printf "%s_%s" ($.Release.Name | upper) $secret.secretKey }}
-        property: {{ ( $secret.property | default $secret.secretKey ) }}
+        property: {{ ( $secret.property | default "" ) }}
         {{- else if eq $type "vault" }}
         key: {{ printf "%s/%s" $secretPath $.Release.Name }}
         property: {{ ( $secret.property | default $secret.secretKey ) }}

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -45,13 +45,13 @@ spec:
       remoteRef:
         {{- if eq $type "gcp" }}
         key: {{ printf "%s_%s" ($.Release.Name | upper) $secret.secretKey }}
-        property: {{ ( $secret.property | default "" ) }}
+        property: {{ $secret.property | default "" }}
         {{- else if eq $type "vault" }}
         key: {{ printf "%s/%s" $secretPath $.Release.Name }}
-        property: {{ ( $secret.property | default $secret.secretKey ) }}
+        property: {{ $secret.property | default $secret.secretKey }}
         {{- else if eq $type "aws" }}
         key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
-        property: {{ ( $secret.property | default $secret.secretKey ) }}
+        property: {{ $secret.property | default $secret.secretKey }}
         {{- else }}
         key: {{ $secret }}
         property: {{ $secret }}

--- a/standard-app/templates/configs/configmap.yaml
+++ b/standard-app/templates/configs/configmap.yaml
@@ -1,72 +1,41 @@
 # Default configMap
 {{- if .Values.configMap }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-configmap
-data:
-  {{- range $key, $value := .Values.configMap }}
-    {{ $key }}: {{ $value }}
-  {{- end }}
+{{- include "standard-app.configMap" (dict "name" .Release.Name "data" .Values.configMap) }}
 ---
 {{- end }}
 
 # Deployment configMap
 {{- range $appName, $appConfig := .Values.apps -}}
-{{- if $appConfig.volumes }}
-{{- range $appConfig.volumes }}
-{{- if .type.configMap }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ $appName }}-configmap
-data:
-  {{- range $key, $value := .configMapData }}
-  {{ $key }}: | 
-    {{ $value | nindent 4 }}
-  {{- end }}
-{{- end }}
+  {{- if $appConfig.volumes }}
+    {{- range $appConfig.volumes }}
+      {{- if .type.configMap }}
+        {{- include "standard-app.configMap" (dict "name" $appName "data" .configMapData) }}
 ---
-{{- end }}
-{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 # cronJob configMap
 {{- range $cronjobName, $cronjobConfig := .Values.cronjobs -}}
-{{- if $cronjobConfig.volumes }}
-{{- range $cronjobConfig.volumes }}
-{{- if .type.configMap }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .type.configMap.name }}
-data:
-  {{- range $key, $value := .configMapData }}
-  {{ $key }}: | 
-    {{ $value | nindent 4 }}
-  {{- end }}
-{{- end }}
+  {{- if $cronjobConfig.volumes }}
+    {{- range $cronjobConfig.volumes }}
+      {{- if .type.configMap }}
+        {{- include "standard-app.configMap" (dict "name" .type.configMap.name "data" .configMapData) }}
 ---
-{{- end }}
-{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 # job configMap
 {{- range $jobName, $jobConfig := .Values.jobs -}}
-{{- if $jobConfig.volumes }}
-{{- range $jobConfig.volumes }}
-{{- if .type.configMap }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .type.configMap.name }}
-data:
-  {{- range $key, $value := .configMapData }}
-  {{ $key }}: | 
-    {{ $value | nindent 4 }}
-  {{- end }}
-{{- end }}
+  {{- if $jobConfig.volumes }}
+    {{- range $jobConfig.volumes }}
+      {{- if .type.configMap }}
+        {{- include "standard-app.configMap" (dict "name" .type.configMap.name "data" .configMapData) }}
 ---
-{{- end }}
-{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -1,569 +1,117 @@
 {{- if .Values.externalSecret }}
+{{- $type := .Values.externalSecret.type }}
+{{- $storeName := .Values.externalSecret.secretStoreName }}
+{{- $secretPath := .Values.externalSecret.secretPath }}
+{{- $refreshInterval := .Values.externalSecret.refreshInterval | default "1m" }}
 
-{{- $apiVersion := "external-secrets.io/v1beta1" -}}
-{{- if .Capabilities.APIVersions.Has "external-secrets.io/v1" -}}
-{{- $apiVersion = "external-secrets.io/v1" -}}
-{{- end -}}
-
-# deployment secrets
+# Deployment secrets
 {{- range $appName, $appConfig := .Values.apps }}
 
-# deployment initcontainer secret
-{{- range $initContainerName, $initContainerConfig := $appConfig.initContainers -}}
-{{- if $initContainerConfig.secrets }}
-apiVersion: {{ $apiVersion }}
-kind: ExternalSecret
-metadata:
-  name: {{ $initContainerName }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: {{ $.Values.externalSecret.secretStoreName }}
-  target:
-    name: {{ $initContainerName }}
-    creationPolicy: Owner
-  {{- if kindIs "map" $initContainerConfig.secrets }}
-  {{- if $initContainerConfig.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-  {{- else }}
-  data:
-  {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $initContainerConfig.secrets  }}
-    - secretKey: {{ $key }}
-      remoteRef:
-        key: {{ $value }}
-    {{- end }}
-  {{- else }}
-    {{- range $secret := $initContainerConfig.secrets }}
-    - secretKey: {{ $secret.secretKey }}
-      remoteRef:
-      {{- if eq $.Values.externalSecret.type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
-      {{- end }}
-      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if kindIs "slice" $initContainerConfig.secrets }}
-  data:
-  {{- range $secret := $initContainerConfig.secrets }}
-    - secretKey: {{ $secret }}
-      remoteRef:
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret }}
-  {{- end }}
-  {{- end }}
+  {{- range $containerType := list "containers" "initContainers" }}
+    {{- range $name, $config := index $appConfig $containerType }}
+      {{- if $config.secrets }}
+        {{- template "standard-app.externalSecret" (dict
+            "name" $name
+            "labels" (merge (dict "app" $appName "product" $.Release.Name) (default dict $.Values.labels))
+            "secrets" $config.secrets
+            "type" $type
+            "storeName" $storeName
+            "secretPath" $secretPath
+            "refreshInterval" $refreshInterval
+            "Values" $.Values
+            "Release" $.Release
+          ) }}
 ---
-{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- if $appConfig.secrets }}
+    {{- template "standard-app.externalSecret" (dict
+        "name" $appName
+        "labels" (merge (dict "app" $appName "product" $.Release.Name) (default dict $.Values.labels))
+        "secrets" $appConfig.secrets
+        "type" $type
+        "storeName" $storeName
+        "secretPath" $secretPath
+        "refreshInterval" $refreshInterval
+        "Values" $.Values
+        "Release" $.Release
+      ) }}
+---
+  {{- end }}
+
 {{- end }}
 
-# deployment container secret
-{{- range $containerName, $containerConfig := $appConfig.containers -}}
-{{- if $containerConfig.secrets }}
-apiVersion: {{ $apiVersion }}
-kind: ExternalSecret
-metadata:
-  name: {{ $containerName }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: {{ $.Values.externalSecret.secretStoreName }}
-  target:
-    name: {{ $containerName }}
-    creationPolicy: Owner
-  {{- if kindIs "map" $containerConfig.secrets }}
-  {{- if $containerConfig.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-  {{- else }}
-  data:
-  {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $containerConfig.secrets  }}
-    - secretKey: {{ $key }}
-      remoteRef:
-        key: {{ $value }}
-    {{- end }}
-  {{- else }}
-    {{- range $secret := $containerConfig.secrets }}
-    - secretKey: {{ $secret.secretKey }}
-      remoteRef:
-      {{- if eq $.Values.externalSecret.type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
-      {{- end }}
-      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if kindIs "slice" $containerConfig.secrets }}
-  data:
-  {{- range $secret := $containerConfig.secrets }}
-    - secretKey: {{ $secret }}
-      remoteRef:
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret }}
-  {{- end }}
-  {{- end }}
----
-{{- end }}
-{{- end }}
-
-# deployment global secret
-{{- if $appConfig.secrets }}
-apiVersion: {{ $apiVersion }}
-kind: ExternalSecret
-metadata:
-  name: {{ $appName }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  refreshInterval: {{ $.Values.externalSecret.refreshInterval | default "1m" }}
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: {{ $.Values.externalSecret.secretStoreName }}
-  target:
-    name: {{ $appName }}
-    creationPolicy: Owner
-  {{- if kindIs "map" $appConfig.secrets }}
-  {{- if $appConfig.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-  {{- else }}
-  data:
-  {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $appConfig.secrets }}
-    - secretKey: {{ $key }}
-      remoteRef:
-        key: {{ $value }}
-    {{- end }}
-  {{- else }}
-    {{- range $secret := $appConfig.secrets }}
-    - secretKey: {{ $secret.secretKey }}
-      remoteRef:
-      {{- if eq $.Values.externalSecret.type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
-      {{- end }}
-      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if kindIs "slice" $appConfig.secrets }}
-  data:
-  {{- range $secret := $appConfig.secrets }}
-    - secretKey: {{ $secret }}
-      remoteRef:
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret }}
-  {{- end }}
-  {{- end }}
----
-{{- end }}
-# close deployment secrets range (line 3)
-{{- end }}
-
-# job secret
+# Jobs
 {{- range $jobName, $jobConfig := .Values.jobs }}
-{{- if $jobConfig.secrets }}
-apiVersion: {{ $apiVersion }}
-kind: ExternalSecret
-metadata:
-  name: {{ $jobName }}
-  labels:
-    app: {{ $jobName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: {{ $.Values.externalSecret.secretStoreName }}
-  target:
-    name: {{ $jobName }}
-    creationPolicy: Owner
-  {{- if kindIs "map" $jobConfig.secrets }}
-    {{- if $jobConfig.dataFrom }}
-  dataFrom:
-  - extract:
-      key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-  {{- else }}
-  data:
-  {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $jobConfig.secrets  }}
-    - secretKey: {{ $key }}
-      remoteRef:
-        key: {{ $value }}
-    {{- end }}
-  {{- else }}
-    {{- range $secret := $jobConfig.secrets }}
-    - secretKey: {{ $secret.secretKey }}
-      remoteRef:
-      {{- if eq $.Values.externalSecret.type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
-      {{- end }}
-      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if kindIs "slice" $jobConfig.secrets }}
-  data:
-  {{- range $secret := $jobConfig.secrets }}
-    - secretKey: {{ $secret }}
-      remoteRef:
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret }}
-  {{- end }}
-  {{- end }}
+  {{- if $jobConfig.secrets }}
+    {{- template "standard-app.externalSecret" (dict
+        "name" $jobName
+        "labels" (merge (dict "app" $jobName "product" $.Release.Name) (default dict $.Values.labels))
+        "secrets" $jobConfig.secrets
+        "type" $type
+        "storeName" $storeName
+        "secretPath" $secretPath
+        "refreshInterval" $refreshInterval
+        "Values" $.Values
+        "Release" $.Release
+      ) }}
 ---
-{{- end }}
+  {{- end }}
 {{- end }}
 
-# global secret
+# CronJobs
+{{- range $cronjobName, $cronjobConfig := .Values.cronjobs }}
+  {{- range $containerType := list "containers" "initContainers" }}
+    {{- range $name, $config := index $cronjobConfig $containerType }}
+      {{- if $config.secrets }}
+        {{- template "standard-app.externalSecret" (dict
+            "name" $name
+            "labels" (merge (dict "app" $cronjobName "product" $.Release.Name) (default dict $.Values.labels))
+            "secrets" $config.secrets
+            "type" $type
+            "storeName" $storeName
+            "secretPath" $secretPath
+            "refreshInterval" $refreshInterval
+            "Values" $.Values
+            "Release" $.Release
+          ) }}
+---
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- if $cronjobConfig.secrets }}
+    {{- template "standard-app.externalSecret" (dict
+        "name" $cronjobName
+        "labels" (merge (dict "app" $cronjobName "product" $.Release.Name) (default dict $.Values.labels))
+        "secrets" $cronjobConfig.secrets
+        "type" $type
+        "storeName" $storeName
+        "secretPath" $secretPath
+        "refreshInterval" $refreshInterval
+        "Values" $.Values
+        "Release" $.Release
+      ) }}
+---
+  {{- end }}
+{{- end }}
+
+
+# Global secret
 {{- if .Values.secrets }}
-apiVersion: {{ $apiVersion }}
-kind: ExternalSecret
-metadata:
-  name: {{ .Release.Name }}
-  labels:
-    app: {{ .Release.Name }}
-    product: {{ .Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: {{ $.Values.externalSecret.secretStoreName }}
-  target:
-    name: {{ .Release.Name }}
-    creationPolicy: Owner
-  {{- if kindIs "map" .Values.secrets }}
-  {{- if .Values.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-  {{- else }}
-  data:
-  {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := .Values.secrets  }}
-    - secretKey: {{ $key }}
-      remoteRef:
-        key: {{ $value }}
-    {{- end }}
-  {{- else }}
-    {{- range $secret := .Values.secrets }}
-    - secretKey: {{ $secret.secretKey }}
-      remoteRef:
-      {{- if eq $.Values.externalSecret.type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
-      {{- end }}
-      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if kindIs "slice" .Values.secrets }}
-  data:
-  {{- range $secret := .Values.secrets }}
-    - secretKey: {{ $secret }}
-      remoteRef:
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret }}
-  {{- end }}
-  {{- end }}
+  {{- template "standard-app.externalSecret" (dict
+      "name" $.Release.Name
+      "labels" (merge (dict "app" $.Release.Name) (default dict $.Values.labels))
+      "secrets" .Values.secrets
+      "type" $type
+      "storeName" $storeName
+      "secretPath" $secretPath
+      "refreshInterval" $refreshInterval
+      "Values" $.Values
+      "Release" $.Release
+    ) }}
 ---
-{{- end }}
-
-# Cronjob secrets
-{{- range $cronjobName, $cronjobConfig := .Values.cronjobs -}}
-# cronjob init container secret
-{{- range $initContainerName, $initContainerConfig := $cronjobConfig.initContainers -}}
-{{- if $initContainerConfig.secrets }}
-apiVersion: {{ $apiVersion }}
-kind: ExternalSecret
-metadata:
-  name: {{ $initContainerName }}
-  labels:
-    app: {{ $cronjobName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: {{ $.Values.externalSecret.secretStoreName }}
-  target:
-    name: {{ $initContainerName }}
-    creationPolicy: Owner
-  {{- if kindIs "map" $initContainerConfig.secrets }}
-  {{- if $initContainerConfig.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-  {{- else }}
-  data:
-  {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $initContainerConfig.secrets }}
-    - secretKey: {{ $key }}
-      remoteRef:
-        key: {{ $value }}
-    {{- end }}
-  {{- else }}
-    {{- range $secret := $initContainerConfig.secrets }}
-    - secretKey: {{ $secret.secretKey }}
-      remoteRef:
-      {{- if eq $.Values.externalSecret.type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
-      {{- end }}
-      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if kindIs "slice" $initContainerConfig.secrets }}
-  data:
-  {{- range $secret := $initContainerConfig.secrets }}
-    - secretKey: {{ $secret }}
-      remoteRef:
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret }}
-  {{- end }}
-  {{- end }}
----
-{{- end }}
-{{- end }}
-
-# cronjob container secret
-{{- range $containerName, $containerConfig := $cronjobConfig.containers -}}
-{{- if $containerConfig.secrets }}
-apiVersion: {{ $apiVersion }}
-kind: ExternalSecret
-metadata:
-  name: {{ $containerName }}
-  labels:
-    app: {{ $cronjobName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: {{ $.Values.externalSecret.secretStoreName }}
-  target:
-    name: {{ $containerName }}
-    creationPolicy: Owner
-  {{- if kindIs "map" $containerConfig.secrets }}
-  {{- if $containerConfig.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-  {{- else }}
-  data:
-  {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $containerConfig.secrets }}
-    - secretKey: {{ $key }}
-      remoteRef:
-        key: {{ $value }}
-    {{- end }}
-  {{- else }}
-    {{- range $secret := $containerConfig.secrets }}
-    - secretKey: {{ $secret.secretKey }}
-      remoteRef:
-      {{- if eq $.Values.externalSecret.type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
-      {{- end }}
-      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if kindIs "slice" $containerConfig.secrets }}
-  data:
-  {{- range $secret := $containerConfig.secrets }}
-    - secretKey: {{ $secret }}
-      remoteRef:
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret }}
-  {{- end }}
-  {{- end }}
----
-{{- end }}
-{{- end }}
-
-# cronjob global secret
-{{- if $cronjobConfig.secrets }}
-apiVersion: {{ $apiVersion }}
-kind: ExternalSecret
-metadata:
-  name: {{ $cronjobName }}
-  labels:
-    app: {{ $cronjobName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: {{ $.Values.externalSecret.secretStoreName }}
-  target:
-    name: {{ $cronjobName }}
-    creationPolicy: Owner
-  {{- if kindIs "map" $cronjobConfig.secrets }}
-  {{- if $cronjobConfig.dataFrom }}
-  dataFrom:
-    - extract:
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-  {{- else }}
-  data:
-  {{- if eq $.Values.externalSecret.type "azure" }}
-    {{- range $key, $value := $cronjobConfig.secrets }}
-    - secretKey: {{ $key }}
-      remoteRef:
-        key: {{ $value }}
-    {{- end }}
-  {{- else }}
-    {{- range $secret := $cronjobConfig.secrets }}
-    - secretKey: {{ $secret.secretKey }}
-      remoteRef:
-      {{- if eq $.Values.externalSecret.type "gcp" }}
-        key: {{ $.Release.Name | upper }}_{{ $secret.secretKey }}
-      {{- end }}
-      {{- if or (eq $.Values.externalSecret.type "vault") (eq $.Values.externalSecret.type "aws") }}
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret.property | default $secret.secretKey }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if kindIs "slice" $cronjobConfig.secrets }}
-  data:
-  {{- range $secret := $cronjobConfig.secrets }}
-    - secretKey: {{ $secret }}
-      remoteRef:
-        {{- if $.Values.externalSecret.secretPath }}
-        key: {{ $.Values.externalSecret.secretPath }}/{{ $.Release.Name }}
-        {{- else }}
-        key: {{ $.Release.Name }}
-        {{- end }}
-        property: {{ $secret }}
-  {{- end }}
-  {{- end }}
----
-{{- end }}
 {{- end }}
 {{- end }}

--- a/standard-app/templates/network/ingress.yaml
+++ b/standard-app/templates/network/ingress.yaml
@@ -62,20 +62,21 @@ spec:
 {{- end }}
 ---
 {{- range $ingName, $ingConfig := .Values.ingresses }}
+{{- $ingValues := dict
+      "component" $ingName
+      "Values"    $.Values
+      "Release"   $.Release
+      "labels"    (merge 
+                    (default (dict) $.Values.labels)
+                    (default (dict) $ingConfig.labels)
+                  )
+    }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $ingName }}
   namespace: {{ $.Release.Namespace }}
-  labels:
-    app: {{ $.Release.Name }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with $ingConfig.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- include "standard-app.labels" $ingValues | nindent 2 }}
 {{- with $ingConfig.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/standard-app/templates/network/service.yaml
+++ b/standard-app/templates/network/service.yaml
@@ -15,6 +15,10 @@ kind: Service
 metadata:
   name: {{ if .fullname }}{{ .fullname }}{{ else }}{{ $appName }}-{{ .name }}{{ end }}
   {{- include "standard-app.labels" $appValues | nindent 2 }}
+  {{- with $appConfig.serviceAnnotations }}
+  annotations:
+  {{ toYaml . | indent 2 }}
+  {{- end }}
 spec:
   type: {{ .type | default "ClusterIP" }}
   ports:
@@ -33,6 +37,10 @@ kind: Service
 metadata:
   name: {{ $appName }}-canary
   {{- include "standard-app.labels" $appValues | nindent 2 }}
+  {{- with $appConfig.serviceAnnotations }}
+  annotations:
+  {{ toYaml . | indent 2 }}
+  {{- end }}
 spec:
   type: {{ $appConfig.service.type | default "ClusterIP" }}
   ports:

--- a/standard-app/templates/network/service.yaml
+++ b/standard-app/templates/network/service.yaml
@@ -1,5 +1,11 @@
 # deployment services
 {{ range $appName, $appConfig := .Values.apps }}
+{{- $appValues := dict
+      "component" $appName
+      "Values"    $.Values
+      "Release"   $.Release
+      "labels"    (default (dict) $.Values.labels)
+    -}}
 
 # deployment global services
 {{- if $appConfig.services }}
@@ -8,16 +14,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ if .fullname }}{{ .fullname }}{{ else }}{{ $appName }}-{{ .name }}{{ end }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- with $appConfig.serviceAnnotations }}
-  annotations:
-  {{ toYaml . | indent 2 }}
-  {{- end }}
+  {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   type: {{ .type | default "ClusterIP" }}
   ports:
@@ -35,16 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $appName }}-canary
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- with $appConfig.annotations }}
-  annotations:
-  {{ toYaml . | indent 4 }}
-  {{- end }}
+  {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   type: {{ $appConfig.service.type | default "ClusterIP" }}
   ports:

--- a/standard-app/templates/pdb.yaml
+++ b/standard-app/templates/pdb.yaml
@@ -1,16 +1,17 @@
 {{ range $appName, $appConfig := .Values.apps }}
+{{- $appValues := dict
+      "component"           $appName
+      "Values"              $.Values
+      "Release"             $.Release
+      "labels" (default (dict) $.Values.labels)
+    -}}
 {{- if $appConfig.pdb }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $appName }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   minAvailable: {{ $appConfig.pdb.minAvailable }}
   selector:

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -19,9 +19,6 @@ Required dict keys:
 {{- $app := .app | default dict -}}
 {{- $appName := .appName -}}
 {{- $global := .global | default dict -}}
-{{- $hasContainerSecrets := hasKey .container "secrets" -}}
-{{- $hasAppSecrets := hasKey $app "secrets" -}}
-{{- $hasValuesSecrets := and (hasKey $global "secrets") (gt (len $global.secrets) 0) -}}
 - name: {{ $name }}
   image: "{{ (.container.image | default $app.image | default $global.image) }}:{{ (.container.tag | default $app.tag | default $global.tag) }}"
   imagePullPolicy: "{{ (.container.imagePullPolicy | default $app.imagePullPolicy | default $global.imagePullPolicy) }}"
@@ -64,17 +61,17 @@ Required dict keys:
       value: {{ $value | quote }}
     {{- end }}
   envFrom:
-    {{- if $hasContainerSecrets }}
+    {{- if hasKey .container "secrets" }}
     - secretRef:
         name: {{ $name }}
     {{- end }}
-    {{- if $hasAppSecrets }}
+    {{- if hasKey $app "secrets" }}
     - secretRef:
         name: {{ $appName }}
     {{- end }}
-    {{- if and .Release (ne .Release.Name "") }}
+    {{- if and (hasKey $global "secrets") (gt (len $global.secrets) 0) }}
     - secretRef:
-        name: {{ .Release.Name }}
+        name: {{ .releaseName }}
     {{- end }}
   {{- if or (hasKey .container "resources") (hasKey $app "resources") }}
   resources:
@@ -95,6 +92,6 @@ Required dict keys:
   {{- end }}
   {{- if hasKey .container "securityContext" }}
   securityContext:
-    {{ toYaml (index .container "securityContext") | nindent 4 }}
+    {{- toYaml (index .container "securityContext") | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -22,15 +22,15 @@ Required dict keys:
 - name: {{ $name }}
   image: "{{ (.container.image | default $app.image | default $global.image) }}:{{ (.container.tag | default $app.tag | default $global.tag) }}"
   imagePullPolicy: "{{ (.container.imagePullPolicy | default $app.imagePullPolicy | default $global.imagePullPolicy) }}"
-  {{- if hasKey .container "command" }}
+  {{- if or (hasKey .container "command") (hasKey $app "command") }}
   command:
-    {{- range index .container "command" }}
+    {{- range or (index .container "command") (index $app "command") }}
     - {{ . | quote }}
     {{- end }}
   {{- end }}
-  {{- if hasKey .container "args" }}
+  {{- if or (hasKey .container "args") (hasKey $app "args") }}
   args:
-    {{- range index .container "args" }}
+    {{- range or (index .container "args") (index $app "args") }}
     - {{ . | quote }}
     {{- end }}
   {{- end }}
@@ -69,7 +69,7 @@ Required dict keys:
     - secretRef:
         name: {{ $appName }}
     {{- end }}
-    {{- if and (hasKey $global "secrets") (gt (len $global.secrets) 0) }}
+    {{- if hasKey $global "secrets" }}
     - secretRef:
         name: {{ .releaseName }}
     {{- end }}
@@ -93,5 +93,8 @@ Required dict keys:
   {{- if hasKey .container "securityContext" }}
   securityContext:
     {{- toYaml (index .container "securityContext") | nindent 4 }}
+  {{- else if hasKey $app "securityContext" }}
+  securityContext:
+    {{- toYaml (index $app "securityContext") | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -1,0 +1,100 @@
+{{/*
+Render a container spec given a container name and config,
+falling back to app-level and global values as needed.
+Supports env, envFrom, volumes, probes, resources, securityContext, etc.
+
+Usage:
+  {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $appConfig "appName" $appName "global" $.Values) | nindent 6 }}
+
+Required dict keys:
+- name        : string - container name
+- container   : dict - container-specific config
+- app         : dict - app-level config
+- appName     : string - app name for secrets etc
+- global      : dict - global values for fallback
+
+*/}}
+{{- define "standard-app.container" -}}
+{{- $name := .name -}}
+{{- $container := .container | default dict -}}
+{{- $app := .app | default dict -}}
+{{- $appName := .appName -}}
+{{- $global := .global | default dict -}}
+- name: {{ $name }}
+  image: "{{ ($container.image | default $app.image | default $global.image) }}:{{ ($container.tag | default $app.tag | default $global.tag) }}"
+  imagePullPolicy: "{{ ($container.imagePullPolicy | default $app.imagePullPolicy | default $global.imagePullPolicy) }}"
+  {{- if $container.command }}
+  command:
+    {{- range $container.command }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if $container.args }}
+  args:
+    {{- range $container.args }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if or $container.ports $app.ports }}
+  ports:
+    {{- if $container.ports -}}
+      {{ toYaml $container.ports | nindent 4 }}
+    {{- else }}
+      {{ toYaml $app.ports | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if or $container.readinessProbe $app.readinessProbe }}
+  readinessProbe:
+    {{- with (or $container.readinessProbe $app.readinessProbe) -}}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if or $container.livenessProbe $app.livenessProbe }}
+  livenessProbe:
+    {{- with (or $container.livenessProbe $app.livenessProbe) -}}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  env:
+    {{- $mergedEnv := merge (default dict $global.env) (default dict $app.env) (default dict $container.env) }}
+    {{- range $key, $value := $mergedEnv }}
+    - name: {{ $key }}
+      value: {{ $value | quote }}
+    {{- end }}
+  envFrom:
+    {{- if or $container.secrets $app.secrets $global.secrets }}
+      {{- if $container.secrets }}
+    - secretRef:
+        name: {{ $name }}
+      {{- end }}
+      {{- if and (not $container.secrets) $app.secrets }}
+    - secretRef:
+        name: {{ $appName }}
+      {{- end }}
+      {{- if and (not $container.secrets) (not $app.secrets) $global.secrets }}
+    - secretRef:
+        name: {{ $global.release.Name }}
+      {{- end }}
+    {{- end }}
+  {{- if or $container.resources $app.resources }}
+  resources:
+    {{- with (or $container.resources $app.resources) -}}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if or $container.volumes $app.volumes }}
+  volumeMounts:
+    {{- $volumes := $container.volumes | default $app.volumes }}
+    {{- range $volumes }}
+    - mountPath: {{ .mountPath }}
+      name: {{ .name }}
+      {{- if .subPath }}
+      subPath: {{ .subPath }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if $container.securityContext }}
+  securityContext:
+    {{ toYaml $container.securityContext | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/standard-app/templates/workloads/cronjob.yaml
+++ b/standard-app/templates/workloads/cronjob.yaml
@@ -42,12 +42,16 @@ spec:
           {{- if $cronjobConfig.initContainers }}
           initContainers:
             {{- range $initContainerName, $initContainerConfig  := $cronjobConfig.initContainers }}
-              {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $cronjobConfig "cronjobName" $cronjobName "Values" $.Values) | nindent 12 }}
+              {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $cronjobConfig "appName" $cronjobName "global" $.Values) | nindent 12 }}
             {{- end }}
           {{- end }}
           containers:
-          {{- range $containerName, $containerConfig := $cronjobConfig.containers }}
-            {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $cronjobConfig "cronjobName" $cronjobName "Values" $.Values) | nindent 12 }}
+          {{- if $cronjobConfig.containers }}
+            {{- range $containerName, $containerConfig := $cronjobConfig.containers }}
+              {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $cronjobConfig "appName" $cronjobName "global" $.Values) | nindent 12 }}
+            {{- end }}
+          {{- else }}
+            {{- include "standard-app.container" (dict "name" $cronjobName "container" (dict) "app" $cronjobConfig "appName" $cronjobName "global" $.Values) | nindent 12 }}
           {{- end }}
           {{- if $cronjobConfig.volumes }}
           volumes:

--- a/standard-app/templates/workloads/cronjob.yaml
+++ b/standard-app/templates/workloads/cronjob.yaml
@@ -1,14 +1,15 @@
 {{- range $cronjobName, $cronjobConfig := .Values.cronjobs }}
+{{- $cronjobValues := dict
+      "component" $cronjobName
+      "Values"    $.Values
+      "Release"   $.Release
+      "labels"    (default (dict) $.Values.labels)
+    -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ $cronjobName }}
-  labels:
-    app: {{ $cronjobName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- include "standard-app.labels" $cronjobValues | nindent 2 }}
 spec:
   schedule: {{ $cronjobConfig.schedule | quote }}
   suspend: {{ $cronjobConfig.suspend | default "false" }}
@@ -16,39 +17,13 @@ spec:
   jobTemplate:
     metadata:
       name: {{ $cronjobName }}
-      labels:
-        app: {{ $cronjobName }}
-        product: {{ $.Release.Name }}
-        {{- with $.Values.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- include "standard-app.labels" $cronjobValues | nindent 6 }}
     spec:
       backoffLimit: {{ $cronjobConfig.backoffLImit | default "0" }}
       template:
         metadata:
-          labels:
-            app: {{ $cronjobName }}
-            product: {{ $.Release.Name }}
-            {{- with $.Values.labels }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+          {{- include "standard-app.labels" $cronjobValues | nindent 10 }}
         spec:
-          {{- if eq $.Values.nodeType "spot" }}
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                - matchExpressions:
-                  - key: cloud.google.com/gke-spot
-                    operator: In
-                    values:
-                    - "true"
-          tolerations:
-            - effect: NoSchedule
-              key: cloud.google.com/gke-spot
-              operator: Equal
-              value: "true"
-          {{- end }}
           {{- if $cronjobConfig.affinity }}
           affinity:
             {{- toYaml $cronjobConfig.affinity | nindent 12 }}
@@ -67,88 +42,13 @@ spec:
           {{- if $cronjobConfig.initContainers }}
           initContainers:
             {{- range $initContainerName, $initContainerConfig  := $cronjobConfig.initContainers }}
-            - name: {{ $initContainerName }}
-              image: "{{- $initContainerConfig.image | default $cronjobConfig.image | default $.Values.image }}:{{- $initContainerConfig.tag | default $cronjobConfig.tag | default $.Values.tag }}"
-              imagePullPolicy: "{{- $initContainerConfig.imagePullPolicy | default $cronjobConfig.imagePullPolicy | default $.Values.imagePullPolicy }}"
-              {{- if $initContainerConfig.command }}
-              command:
-                {{- range $initContainerConfig.command }} 
-                - {{ . | quote }}
-                {{- end }}
-              {{- end }}
-              args:
-                {{- range $initContainerConfig.args }}
-                - {{ . | quote -}}
-                {{ end }}
-              {{- if $cronjobConfig.volumes }}
-              volumeMounts:
-                {{- range $cronjobConfig.volumes }}
-                - mountPath: {{ .mountPath }}
-                  name: {{ .name }}
-                {{- end }}
-              {{- end }}
-              env:
-                {{- range $key, $value := $initContainerConfig.env }}
-                - name: {{ $key }}
-                  value: {{ $value | quote }}
-                {{- end }}
-              envFrom:
-                {{- if $initContainerConfig.secrets }}
-                - secretRef:
-                    name: {{ $initContainerName }}
-                {{- end }}
-                {{- if $.Values.secrets }}
-                - secretRef:
-                    name: {{ $.Release.Name }}
-                {{- end }}
+              {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $cronjobConfig "cronjobName" $cronjobName "Values" $.Values) | nindent 12 }}
             {{- end }}
           {{- end }}
           containers:
           {{- range $containerName, $containerConfig := $cronjobConfig.containers }}
-            - name: {{ $containerName }}
-              {{- if $containerConfig.image }}
-              image: "{{- $containerConfig.image | default $cronjobConfig.image | default $.Values.image }}:{{- $containerConfig.tag | default $cronjobConfig.tag | default $.Values.tag }}"
-              imagePullPolicy: "{{- $containerConfig.imagePullPolicy | default $cronjobConfig.imagePullPolicy | default $.Values.imagePullPolicy }}"
-              {{- else }}
-              image: "{{ $.Values.image }}:{{ $.Values.tag }}"
-              imagePullPolicy: "{{ $.Values.imagePullPolicy }}"
-              {{- end }}
-              {{- if $containerConfig.command }}
-              command:
-                {{- range $containerConfig.command }} 
-                - {{ . | quote }}
-                {{- end }}
-              {{- end }}
-              args: 
-                {{- range $containerConfig.args }}
-                - {{ . | quote -}}
-                {{ end }}
-              {{- with $containerConfig.resources }}
-              resources:
-                {{- toYaml . | nindent 16 }}
-              {{- end }}
-              {{- if $cronjobConfig.volumes }}
-              volumeMounts:
-                {{- range $cronjobConfig.volumes }}
-                - mountPath: {{ .mountPath }}
-                  name: {{ .name }}
-                {{- end }}
-              {{- end }}
-              env:
-                {{- range $key, $value := merge (default dict $cronjobConfig.env) (default dict $.Values.env) (default dict $containerConfig.env) }}
-                - name: {{ $key }}
-                  value: {{ $value | quote }}
-                {{- end }}
-              envFrom:
-                {{- if $containerConfig.secrets }}
-                - secretRef:
-                    name: {{ $containerName }}
-                {{- end }}
-                {{- if $.Values.secrets }}
-                - secretRef:
-                    name: {{ $.Release.Name }}
-                {{- end }}
-            {{- end }}
+            {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $cronjobConfig "cronjobName" $cronjobName "Values" $.Values) | nindent 12 }}
+          {{- end }}
           {{- if $cronjobConfig.volumes }}
           volumes:
             {{- range $cronjobConfig.volumes }}

--- a/standard-app/templates/workloads/cronjob.yaml
+++ b/standard-app/templates/workloads/cronjob.yaml
@@ -42,16 +42,16 @@ spec:
           {{- if $cronjobConfig.initContainers }}
           initContainers:
             {{- range $initContainerName, $initContainerConfig  := $cronjobConfig.initContainers }}
-              {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $cronjobConfig "appName" $cronjobName "global" $.Values) | nindent 12 }}
+              {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $cronjobConfig "appName" $cronjobName "global" $.Values "releaseName" $.Release.Name) | nindent 12 }}
             {{- end }}
           {{- end }}
           containers:
           {{- if $cronjobConfig.containers }}
             {{- range $containerName, $containerConfig := $cronjobConfig.containers }}
-              {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $cronjobConfig "appName" $cronjobName "global" $.Values) | nindent 12 }}
+              {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $cronjobConfig "appName" $cronjobName "global" $.Values "releaseName" $.Release.Name) | nindent 12 }}
             {{- end }}
           {{- else }}
-            {{- include "standard-app.container" (dict "name" $cronjobName "container" (dict) "app" $cronjobConfig "appName" $cronjobName "global" $.Values) | nindent 12 }}
+            {{- include "standard-app.container" (dict "name" $cronjobName "container" (dict) "app" $cronjobConfig "appName" $cronjobName "global" $.Values "releaseName" $.Release.Name) | nindent 12 }}
           {{- end }}
           {{- if $cronjobConfig.volumes }}
           volumes:

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -68,6 +68,15 @@ spec:
         {{- end }}
       {{- else }}
         {{- include "standard-app.container" (dict "name" $appName "container" (dict) "app" $appConfig "appName" $appName "global" $.Values "releaseName" $.Release.Name) | nindent 8 }}
-      {{- end }}    
+      {{- end }}  
+      {{- if $appConfig.volumes }}
+      volumes:
+        {{- range $appConfig.volumes }}
+        - name: {{ .name }}
+          {{- with .type }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}  
 ---
 {{- end }}

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -58,16 +58,16 @@ spec:
       {{- if $appConfig.initContainers }}
       initContainers:
         {{- range $initContainerName, $initContainerConfig  := $appConfig.initContainers }}
-          {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $appConfig "appName" $appName "Values" $.Values) | nindent 8 }}
+          {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $appConfig "appName" $appName "global" $.Values) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
       {{- if $appConfig.containers }}
         {{- range $containerName, $containerConfig  := $appConfig.containers }}
-          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $appConfig "appName" $appName "Values" $.Values) | nindent 8 }}
+          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $appConfig "appName" $appName "global" $.Values) | nindent 8 }}
         {{- end }}
       {{- else }}
-        {{- include "standard-app.container" (dict "name" $appName "container" dict "app" $appConfig "appName" $appName "Values" $.Values) | nindent 8 }}
+        {{- include "standard-app.container" (dict "name" $appName "container" (dict) "app" $appConfig "appName" $appName "global" $.Values) | nindent 8 }}
       {{- end }}    
 ---
 {{- end }}

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -58,16 +58,16 @@ spec:
       {{- if $appConfig.initContainers }}
       initContainers:
         {{- range $initContainerName, $initContainerConfig  := $appConfig.initContainers }}
-          {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $appConfig "appName" $appName "global" $.Values) | nindent 8 }}
+          {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $appConfig "appName" $appName "global" $.Values "releaseName" $.Release.Name) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
       {{- if $appConfig.containers }}
         {{- range $containerName, $containerConfig  := $appConfig.containers }}
-          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $appConfig "appName" $appName "global" $.Values) | nindent 8 }}
+          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $appConfig "appName" $appName "global" $.Values "releaseName" $.Release.Name) | nindent 8 }}
         {{- end }}
       {{- else }}
-        {{- include "standard-app.container" (dict "name" $appName "container" (dict) "app" $appConfig "appName" $appName "global" $.Values) | nindent 8 }}
+        {{- include "standard-app.container" (dict "name" $appName "container" (dict) "app" $appConfig "appName" $appName "global" $.Values "releaseName" $.Release.Name) | nindent 8 }}
       {{- end }}    
 ---
 {{- end }}

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -1,14 +1,15 @@
 {{- range $appName, $appConfig := .Values.apps }}
+{{- $appValues := dict
+      "component" $appName
+      "Values"    $.Values
+      "Release"   $.Release
+      "labels"    (default (dict) $.Values.labels)
+    }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $appName }}
-  labels:
-    app: {{ $appName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   {{- if not $appConfig.hpa }}
   replicas: {{ $appConfig.replicas }}
@@ -23,12 +24,7 @@ spec:
       app: {{ $appName }}
   template:
     metadata:
-      labels:
-        app: {{ $appName }}
-        product: {{ $.Release.Name }}
-        {{- with $.Values.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- include "standard-app.labels" $appValues | nindent 6 }}
       annotations:
         {{- if $appConfig.podAnnotations }}
         {{- toYaml $appConfig.podAnnotations | nindent 8 }}
@@ -40,22 +36,6 @@ spec:
         secret.reloader.stakater.com/reload: {{ $.Release.Name }}
         {{- end }}
     spec:
-      {{- if eq $.Values.nodeType "spot" }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: cloud.google.com/gke-spot
-                operator: In
-                values:
-                - "true"
-      tolerations:
-        - effect: NoSchedule
-          key: cloud.google.com/gke-spot
-          operator: Equal
-          value: "true"
-      {{- end }}
       {{- if $appConfig.affinity }}
       affinity:
         {{- toYaml $appConfig.affinity | nindent 8 }}
@@ -78,215 +58,16 @@ spec:
       {{- if $appConfig.initContainers }}
       initContainers:
         {{- range $initContainerName, $initContainerConfig  := $appConfig.initContainers }}
-        - name: {{ $initContainerName }}
-          image: "{{- $initContainerConfig.image | default $appConfig.image | default $.Values.image }}:{{- $initContainerConfig.tag | default $appConfig.tag | default $.Values.tag }}"
-          imagePullPolicy: "{{- $initContainerConfig.imagePullPolicy | default $appConfig.imagePullPolicy | default $.Values.imagePullPolicy }}"
-          {{- if $initContainerConfig.command }}
-          command:
-            {{- range $initContainerConfig.command }} 
-            - {{ . | quote }}
-            {{- end }}
-          {{- end }}
-          {{- if $initContainerConfig.args }}
-          args:
-            {{- range $initContainerConfig.args }}
-            - {{ . | quote -}}
-            {{ end }}
-          {{- end }}
-          {{- if $initContainerConfig.volumes }}
-          volumeMounts:
-            {{- range $initContainerConfig.volumes }}
-            - mountPath: {{ .mountPath }}
-              name: {{ .name }}
-            {{- end }}
-          {{- else if $appConfig.volumes }}
-          volumeMounts:
-            {{- range $appConfig.volumes }}
-            - mountPath: {{ .mountPath }}
-              name: {{ .name }}
-            {{- end }}
-          {{- end }}
-          {{- if $initContainerConfig.env }}
-          env:
-            {{- range $key, $value := $initContainerConfig.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-          {{- end }}
-          envFrom:
-            {{- if $initContainerConfig.secrets }}
-            - secretRef:
-                name: {{ $initContainerName }}
-            {{- end }}
-            {{- if $.Values.secrets }}
-            - secretRef:
-                name: {{ $.Release.Name }}
-            {{- end }}
+          {{- include "standard-app.container" (dict "name" $initContainerName "container" $initContainerConfig "app" $appConfig "appName" $appName "Values" $.Values) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
       {{- if $appConfig.containers }}
         {{- range $containerName, $containerConfig  := $appConfig.containers }}
-        - name: {{ $containerName }}
-          image: "{{- $containerConfig.image | default $appConfig.image | default $.Values.image }}:{{- $containerConfig.tag | default $appConfig.tag | default $.Values.tag }}"
-          imagePullPolicy: "{{- $containerConfig.imagePullPolicy | default $appConfig.imagePullPolicy | default $.Values.imagePullPolicy }}"
-          {{- if $containerConfig.command }}
-          command:
-            {{- range $containerConfig.command }} 
-            - {{ . | quote }}
-            {{- end }}
-          {{- end }}
-          {{- if $containerConfig.args }}
-          args:
-            {{- range $containerConfig.args }}
-            - {{ . | quote -}}
-            {{ end }}
-          {{ end }}
-          {{- if $containerConfig.ports }}
-          ports:
-            {{- toYaml $containerConfig.ports | nindent 12 }}
-          {{- else if $appConfig.ports }}
-          ports:
-            {{- toYaml $appConfig.ports | nindent 12 }}
-          {{- end }}
-          {{- if $containerConfig.readinessProbe }}
-          readinessProbe:
-            {{- with $containerConfig.readinessProbe }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- else if $appConfig.readinessProbe }}
-          readinessProbe:
-            {{- with $appConfig.readinessProbe }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          {{- if $containerConfig.livenessProbe }}
-          livenessProbe:
-            {{- with $containerConfig.livenessProbe }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- else if $appConfig.livenessProbe }}
-          livenessProbe:
-            {{- with $appConfig.livenessProbe }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          env:
-            {{- range $key, $value := merge (default dict $containerConfig.env) (default dict $appConfig.env) (default dict $.Values.env) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-          envFrom:
-            {{- if $containerConfig.secrets }}
-            - secretRef:
-                name: {{ $containerName }}
-            {{- end }}
-            {{- if $appConfig.secrets }}
-            - secretRef:
-                name: {{ $appName }}
-            {{- end }}
-            {{- if $.Values.secrets }}
-            - secretRef:
-                name: {{ $.Release.Name }}
-            {{- end }}
-          {{- if $containerConfig.resources }}
-          resources:
-            {{- with $containerConfig.resources }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- else if $appConfig.resources }}
-          resources:
-            {{- with $appConfig.resources }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          {{- if $containerConfig.volumes }}
-          volumeMounts:
-            {{- range $containerConfig.volumes }}
-            - mountPath: {{ .mountPath }}
-              name: {{ .name }}
-              subPath: {{ .subPath }}
-            {{- end }}
-          {{- else if $appConfig.volumes }}
-          volumeMounts:
-            {{- range $appConfig.volumes }}
-            - mountPath: {{ .mountPath }}
-              name: {{ .name }}
-              subPath: {{ .subPath }}
-            {{- end }}
-          {{- end }}
-          {{- if $containerConfig.securityContext }}
-          securityContext:
-            {{- toYaml $containerConfig.securityContext | nindent 12 }}
-          {{- end }}
+          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $appConfig "appName" $appName "Values" $.Values) | nindent 8 }}
         {{- end }}
       {{- else }}
-        - name: {{ $appName }}
-          image: "{{- $appConfig.image | default $.Values.image }}:{{- $appConfig.tag | default $.Values.tag }}"
-          imagePullPolicy: "{{- $appConfig.imagePullPolicy | default $.Values.imagePullPolicy }}"
-          {{- if $appConfig.command }}
-          command:
-            {{- range $appConfig.command }} 
-            - {{ . | quote }}
-            {{- end }}
-          {{- end }}
-          {{- if $appConfig.args }}
-          args:
-            {{- range $appConfig.args }}
-            - {{ . }}
-            {{- end }}
-          {{- end }}
-          {{- if $appConfig.ports }}
-          ports:
-            {{- toYaml $appConfig.ports | nindent 12 }}
-          {{- end }}
-          {{- with $appConfig.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with $appConfig.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          env:
-            {{- range $key, $value := merge (default dict $appConfig.env) (default dict $.Values.env) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-          envFrom:
-            {{- if $appConfig.secrets }}
-            - secretRef:
-                name: {{ $appName }}
-            {{- end }}
-            {{- if $.Values.secrets }}
-            - secretRef:
-                name: {{ $.Release.Name }}
-            {{- end }}
-          {{- with $appConfig.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if $appConfig.volumes }}
-          volumeMounts:
-            {{- range $appConfig.volumes }}
-            - mountPath: {{ .mountPath }}
-              name: {{ .name }}
-              subPath: {{ .subPath }}
-            {{- end }}
-          {{- end }}
-          {{- if $appConfig.securityContext }}
-          securityContext:
-            {{- toYaml $appConfig.securityContext | nindent 12 }}
-          {{- end }}
-        {{- end }}
-      {{- if $appConfig.volumes }}
-      volumes:
-        {{- range $appConfig.volumes }}
-        - name: {{ .name }}
-          {{- with .type }}
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
-        {{- end }}
+        {{- include "standard-app.container" (dict "name" $appName "container" dict "app" $appConfig "appName" $appName "Values" $.Values) | nindent 8 }}
       {{- end }}    
 ---
 {{- end }}

--- a/standard-app/templates/workloads/job.yaml
+++ b/standard-app/templates/workloads/job.yaml
@@ -37,10 +37,10 @@ spec:
       containers:
           {{- if $jobConfig.containers }}
         {{- range $containerName, $containerConfig  := $jobConfig.containers }}
-          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $jobConfig "appName" $jobName "global" $.Values) | nindent 8 }}
+          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $jobConfig "appName" $jobName "global" $.Values "releaseName" $.Release.Name) | nindent 8 }}
         {{- end }}
       {{- else }}
-        {{- include "standard-app.container" (dict "name" $jobName "container" (dict) "app" $jobConfig "appName" $jobName "global" $.Values) | nindent 8 }}
+        {{- include "standard-app.container" (dict "name" $jobName "container" (dict) "app" $jobConfig "appName" $jobName "global" $.Values "releaseName" $.Release.Name) | nindent 8 }}
       {{- end }}
       {{- if $jobConfig.volumes }}
       volumes:

--- a/standard-app/templates/workloads/job.yaml
+++ b/standard-app/templates/workloads/job.yaml
@@ -1,4 +1,10 @@
 {{- range $jobName, $jobConfig := .Values.jobs }}
+{{- $jobValues := dict
+      "component" $jobName
+      "Values"    $.Values
+      "Release"   $.Release
+      "labels"    (default (dict) $.Values.labels)
+    -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -7,38 +13,12 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  labels:
-    app: {{ $jobName }}
-    product: {{ $.Release.Name }}
-    {{- with $.Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }} 
+  {{- include "standard-app.labels" $jobValues | nindent 2 }}
 spec:
   template:
     metadata:
-      labels:
-        app: {{ $jobName }}
-        product: {{ $.Release.Name }}
-        {{- with $.Values.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- include "standard-app.labels" $jobValues | nindent 6 }}
     spec:
-      {{- if eq $.Values.nodeType "spot" }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: cloud.google.com/gke-spot
-                operator: In
-                values:
-                - "true"
-      tolerations:
-        - effect: NoSchedule
-          key: cloud.google.com/gke-spot
-          operator: Equal
-          value: "true"
-      {{- end }}
       {{- if $jobConfig.affinity }}
       affinity:
         {{- toYaml $jobConfig.affinity | nindent 8 }}
@@ -55,49 +35,11 @@ spec:
       serviceAccountName: {{ $jobConfig.serviceAccount }}
       {{- end }}
       containers:
-        - name: {{ $.Release.Name }}-{{ $jobName }}
-          image: "{{- $jobConfig.image | default $.Values.image }}:{{- $jobConfig.tag | default $.Values.tag }}"
-          imagePullPolicy: "{{- $jobConfig.imagePullPolicy | default $.Values.imagePullPolicy }}"
-          {{- if $jobConfig.command }}
-          command: 
-            {{- range $jobConfig.command }}
-            - {{ . | quote}}
-            {{- end }}
-          {{- end }}
-          {{- if $jobConfig.args | quote }}
-          args:
-            {{- range $jobConfig.args }}
-            - {{ . }}
-            {{- end }}
-          {{- end }}
-          env:
-            {{- range $key, $value := merge (default dict $jobConfig.env) (default dict $.Values.env) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-          envFrom:
-            {{- if $jobConfig.secrets }}
-            - secretRef:
-                name: {{ $jobName }}
-            {{- end }}
-            {{- if $.Values.secrets }}
-            - secretRef:
-                name: {{ $.Release.Name }}
-            {{- end }}
-          {{- with $jobConfig.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if $jobConfig.volumes }}
-          volumeMounts:
-            {{- range $jobConfig.volumes }}
-            - mountPath: {{ .mountPath }}
-              name: {{ .name }}
-              {{- if .subPath }}
-              subPath: {{ .subPath }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
+      {{- if $jobConfig.containers }}
+        {{- range $containerName, $containerConfig  := $jobConfig.containers }}
+          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $jobConfig "jobName" $jobName "Values" $.Values) | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if $jobConfig.volumes }}
       volumes:
         {{- range $jobConfig.volumes }}

--- a/standard-app/templates/workloads/job.yaml
+++ b/standard-app/templates/workloads/job.yaml
@@ -35,10 +35,12 @@ spec:
       serviceAccountName: {{ $jobConfig.serviceAccount }}
       {{- end }}
       containers:
-      {{- if $jobConfig.containers }}
+          {{- if $jobConfig.containers }}
         {{- range $containerName, $containerConfig  := $jobConfig.containers }}
-          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $jobConfig "jobName" $jobName "Values" $.Values) | nindent 8 }}
+          {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $jobConfig "appName" $jobName "global" $.Values) | nindent 8 }}
         {{- end }}
+      {{- else }}
+        {{- include "standard-app.container" (dict "name" $jobName "container" (dict) "app" $jobConfig "appName" $jobName "global" $.Values) | nindent 8 }}
       {{- end }}
       {{- if $jobConfig.volumes }}
       volumes:


### PR DESCRIPTION
1. Abstracted `ConfigMap`, `ExternalSecret`, `Ingress`, `Service`, `labels` and `Container` into .tpl files and replaced with `include` statements with passed parameters
2. *Breaking change* Reworked ExternalSecrets' `dataFrom` entry: it now accepts a list of secret names to extract all secrets from
3. Fixed bugs with secrets mapping, env vars and secrets inheritance, resources and volumeMounts not being passed to cronjobs, secrets refresh interval in the values not being respected
4. Changed GHA trigger from `on.push` to `on.release.types[created]`
5. Set version to 1.0.0

`labels`, `env`, and `secrets` are currently merged in a top-down manner — from the root level (`.Values`), to the workload level (`job`, `cronjob`, or `deployment`), and finally to the `container` (or `initContainer`) level. This allows them to be defined as broadly or as specifically as needed for each part of the workload.