### PR TITLE
[rework-structure] branch-off work on external-secret

### DIFF
--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -41,7 +41,7 @@ spec:
     {{- end }}
     {{- range $secret := $secrets }}
       {{- if kindIs "map" $secret }}
-    - secretKey: {{ $secret.property | default $secret.secretKey }}
+    - secretKey: {{ if and (eq $type "gcp") $secret.property }}{{ $secret.property }}{{ else }}{{ $secret.secretKey }}{{ end }}
       remoteRef:
         {{- if eq $type "gcp" }}
         key: {{ printf "%s_%s" ($.Release.Name | upper) $secret.secretKey }}

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -41,7 +41,7 @@ spec:
     {{- end }}
     {{- range $secret := $secrets }}
       {{- if kindIs "map" $secret }}
-    - secretKey: {{ $secret.secretKey }}
+    - secretKey: {{ $secret.property | default $secret.secretKey }}
       remoteRef:
         {{- if eq $type "gcp" }}
         key: {{ printf "%s_%s" ($.Release.Name | upper) $secret.secretKey }}
@@ -61,7 +61,6 @@ spec:
       remoteRef:
         {{- if eq $type "gcp" }}
         key: {{ printf "%s_%s" ($.Release.Name | upper) $secret }}
-        property: {{ $secret }}
         {{- else }}
         key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
         property: {{ $secret }}


### PR DESCRIPTION
This PR:
- Uses `secret.property` as the secretKey in Kubernetes secret if there's a `property` in the secret declaration instead of `key` name. Before, when we have something like this:
```
secrets:
      - secretKey: MONGO_CRED
        property: mongo-username
      - secretKey: MONGO_CRED
        property: mongo-password
```
We get(same Kubernetes secret key name, could break external-secret):
```
- secretKey: MONGO_CRED
      remoteRef:
        key: HELM-STANDARD-LIBRARY_MONGO_CRED
        property: mongo-username
    - secretKey: MONGO_CRED
      remoteRef:
        key: HELM-STANDARD-LIBRARY_MONGO_CRED
        property: mongo-password
```
Now with this change, with the same secret declaration, we get:
```
- secretKey: mongo-username
      remoteRef:
        key: HELM-STANDARD-LIBRARY_MONGO_CRED
        property: mongo-username
    - secretKey: mongo-password
      remoteRef:
        key: HELM-STANDARD-LIBRARY_MONGO_CRED
        property: mongo-password
```

- Second change, we removed `property: {{ $secret }}` in the `$type "gcp" because I don't think it would need property if the secret declaration is just:
```
secrets:
  - MONGO_URL
```
If the secret requires specific properties, then adding `- secretKey: MONGO_URL` would be beneficial in the secret declaration

It might work for other cloud providers as well, such as AWS, but this is similar to a GCP approach, @kirill-cloudkite. What do you think?