### PR TITLE
allow user to specify revision history limit for replicas

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.1.0
+version: 1.1.1
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -423,6 +423,7 @@ apps:
       maxReplicas: 3
       minReplicas: 2
       cpuTarget: 80
+    revisionHistoryLimit: 7
     replicas: 2
     pdb:
       minAvailable: 2

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   {{- if not $appConfig.hpa }}
   replicas: {{ $appConfig.replicas }}
   {{- end }}
-  revisionHistoryLimit: 2
+  revisionHistoryLimit: {{ $appConfig.revisionHistoryLimit | default 2 }}
   {{- if $appConfig.strategyType }}
   strategy:
     type: {{ $appConfig.strategyType }}


### PR DESCRIPTION
Replaces hard coded default for `revisionHistoryLimit` with a configurable field but also a fallback to 2.