### PR TITLE
allow suppport for external-secrets.io/v1

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.1.1
+version: 1.2.0
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -10,7 +10,11 @@
 {{- $secretPath := .secretPath }}
 {{- $refreshInterval := .refreshInterval | default "1m" }}
 
+{{ if .Capabilities.APIVersions.Has "external-secrets.io/v1/ExternalSecret" }}
+apiVersion: external-secrets.io/v1
+{{ else }}
 apiVersion: external-secrets.io/v1beta1
+{{ end }}
 kind: ExternalSecret
 metadata:
   name: {{ $name }}

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -10,7 +10,7 @@
 {{- $secretPath := .secretPath }}
 {{- $refreshInterval := .refreshInterval | default "1m" }}
 
-{{ if .Capabilities.APIVersions.Has "external-secrets.io/v1/ExternalSecret" }}
+{{ if and (.Capabilities) (.Capabilities.APIVersions.Has "external-secrets.io/v1/ExternalSecret") }}
 apiVersion: external-secrets.io/v1
 {{ else }}
 apiVersion: external-secrets.io/v1beta1


### PR DESCRIPTION
adds a check for v1 of external-secrets and uses that if available, else use v1beta1.
Note, a future version will deprecate support for v1beta1