### PR TITLE
use mergeOverwrite for correct behavior when overwriting container envs

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.3.1
+version: 1.3.2
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -55,7 +55,7 @@ Required dict keys:
     {{- end }}
   {{- end }}
   env:
-    {{- $mergedEnv := merge (default dict (index $global "env")) (default dict (index $app "env")) (default dict (index .container "env")) }}
+    {{- $mergedEnv := mergeOverwrite (dict) (default dict (index $global "env")) (default dict (index $app "env")) (default dict (index .container "env")) }}
     {{- range $key, $value := $mergedEnv }}
     - name: {{ $key }}
       value: {{ $value | quote }}


### PR DESCRIPTION
Replace `merge` with `mergeOverwrite` which provides right-to-left precedence, ensuring container-level environment variables correctly override app-level variables, which override global variables.

Expected behavior: `Container > App > Global`