### PR TITLE
allow jobs to use provided name

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.3.3
+version: 1.3.4
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -533,7 +533,21 @@ jobs:
           - matchExpressions:
             - key: cloud.google.com/gke-preemptible
               operator: DoesNotExist
-
+  jobexample-2:
+    useNamePrefix: false
+    annotations:
+      argocd.argoproj.io/hook: PreSync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    command:
+      - "sh"
+      - "-c"
+      - "alembic upgrade head"
+    resources:
+      requests:
+        memory: 0.5Gi
+        cpu: 50m
+      limits:
+        memory: 0.5Gi
 cronjobs:
   cronjobexample-1:
     schedule: 0 6 * * *

--- a/standard-app/templates/workloads/job.yaml
+++ b/standard-app/templates/workloads/job.yaml
@@ -8,7 +8,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- if eq $jobConfig.useNamePrefix false }}
+  name: {{ $jobName }}
+  {{- else }}
   generateName: "{{ $jobName }}-"
+  {{- end }}
   {{- with $jobConfig.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Adds a flag to allow jobs to use a provided name instead of generating one