### PR TITLE
Add missing keys auto added by ES chart

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.3.5
+version: 1.3.6
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -47,27 +47,41 @@ spec:
         {{- if eq $type "gcp" }}
         key: {{ printf "%s_%s" ($.Release.Name | upper) $secret.secretKey }}
         property: {{ $secret.property | default "" }}
+        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
+        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- else if eq $type "vault" }}
         key: {{ printf "%s/%s" $secretPath $.Release.Name }}
         property: {{ $secret.property | default $secret.secretKey }}
+        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
+        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- else if eq $type "aws" }}
         key: {{ if $secret.key }}{{ $secret.key }}{{ else }}{{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}{{ end }}
         property: {{ $secret.property | default $secret.secretKey }}
+        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
+        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- else }}
         key: {{ $secret }}
         property: {{ $secret }}
+        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
+        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- end }}
       {{- else }}
     - secretKey: {{ $secret }}
       remoteRef:
         {{- if eq $type "gcp" }}
         key: {{ printf "%s_%s" ($.Release.Name | upper) $secret }}
+        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
+        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- else if eq $type "aws" }}
         key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
         property: {{ $secret }}
+        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
+        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- else }}
         key: {{ $secret }}
         property: {{ $secret }}
+        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
+        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- end }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
External secrets chart by default sets these keys causing ArgoCD deployment to stay in `Out of Sync` status.

Bump version to `1.3.6`