### PR TITLE
Fix: Adjust extra external-secrets key for list of scalars secrets

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.3.6
+version: 1.3.7
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -70,18 +70,18 @@ spec:
       remoteRef:
         {{- if eq $type "gcp" }}
         key: {{ printf "%s_%s" ($.Release.Name | upper) $secret }}
-        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
-        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
+        conversionStrategy: "Default"
+        decodingStrategy: "None"
         {{- else if eq $type "aws" }}
         key: {{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}
         property: {{ $secret }}
-        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
-        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
+        conversionStrategy: "Default"
+        decodingStrategy: "None"
         {{- else }}
         key: {{ $secret }}
         property: {{ $secret }}
-        conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
-        decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
+        conversionStrategy: "Default"
+        decodingStrategy: "None"
         {{- end }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
This PR:
- Fix the `conversionStrategy` & `decodingStrategy` external-secrets keys for secrets in a list format. Example:
```
secrets:
    - SNOWFLAKE_PASSWORD
    - POSTGRESQL_PASSWORD
```
The above examples aren’t maps, so they don’t support additional key/value pairs.