### PR TITLE
fix: Update External-Secrets API version v1/v1beta1

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.3.8
+version: 1.3.9
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.externalSecret }}
-{{- $apiVersion := ternary "external-secrets.io/v1" "external-secrets.io/v1beta1" ($.Capabilities.APIVersions.Has "external-secrets.io/v1/ExternalSecret") -}}
+{{- $apiVersion := ternary "external-secrets.io/v1" "external-secrets.io/v1beta1" (has "external-secrets.io/v1" .Capabilities.APIVersions) -}}
 {{- $type := .Values.externalSecret.type }}
 {{- $storeName := .Values.externalSecret.secretStoreName }}
 {{- $secretPath := .Values.externalSecret.secretPath }}


### PR DESCRIPTION
This PR:
- Made sure users can still use the external-secrets version `v1beta1` and `v1`