### PR TITLE
fix: correct how labels are added to resources

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.3.10
+version: 1.3.11
 maintainters:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -57,6 +57,8 @@ ingresses:
     annotations:
       kubernetes.io/tls-acme: "true"
       ingress.kubernetes.io/ssl-redirect: "true"
+    labels:
+      cloudkite-app-1-webhook_label1: value1
     hosts:
       - test-callbacks.dev.someorg.com
     # option to add a pre-generated certficate secret
@@ -151,6 +153,9 @@ apps:
           - /etc/scripts/script1.sh
         secrets:
           - secretKey: example
+    labels:
+      example-app-1_label1: thisvalue
+      example-app-1_label2: thatvalue
     containers:
       example-container-1:
         image: us-central1-docker.pkg.dev/cloudkite-infra-ops/cloudkite-docker-images/app-1
@@ -308,6 +313,9 @@ apps:
       runAsGroup: 3000
   
   example-app-1a:
+    labels:
+      example-app-1a_label1: thisvalue
+      example-app-1a_label2: thatvalue
     # Single structure for containers
     containers:
       container1:
@@ -505,6 +513,9 @@ jobs:
   jobexample-1:
     annotations:
       annotation1: value1
+    labels:
+      jobexample-1_label1: value1
+      jobexample-1_label2: value2
     command:
       - "cmd1"
     args:
@@ -555,9 +566,13 @@ jobs:
         cpu: 50m
       limits:
         memory: 0.5Gi
+
 cronjobs:
   cronjobexample-1:
     schedule: 0 6 * * *
+    labels:
+      cronjobexample-1_label1: value1
+      cronjobexample-1_label2: value2
     resources:
       requests:
         memory: 0.5Gi
@@ -636,6 +651,7 @@ cronjobs:
           - secretKey: appsettings.json
             property: APPSETTINGS_JSON
           - secretKey: SOURCE_PROJECT_ID
+
 healthCheckPolicy:
   port: 80 # Optional, defaults to 80
   requestPath: / # Optional, defaults to /

--- a/standard-app/templates/_labels.tpl
+++ b/standard-app/templates/_labels.tpl
@@ -1,5 +1,4 @@
 {{- define "standard-app.labels" -}}
 {{- $defaultLabels := dict "app" .component "product" .Release.Name -}}
-labels:
 {{- toYaml (merge $defaultLabels (default dict .labels)) | nindent 2 }}
 {{- end }}

--- a/standard-app/templates/autoscaling/hpa.yaml
+++ b/standard-app/templates/autoscaling/hpa.yaml
@@ -10,7 +10,8 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $appName }}
-  {{- include "standard-app.labels" $appValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   maxReplicas: {{ $appConfig.hpa.maxReplicas }}
   minReplicas: {{ $appConfig.hpa.minReplicas }}

--- a/standard-app/templates/autoscaling/mpa.yaml
+++ b/standard-app/templates/autoscaling/mpa.yaml
@@ -10,7 +10,8 @@ apiVersion: autoscaling.gke.io/v1beta1
 kind: MultidimPodAutoscaler
 metadata:
   name: {{ $appName }}
-  {{- include "standard-app.labels" $appValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   scaleTargetRef:
     apiVersion: {{ if $appConfig.rollout }}argoproj.io/v1alpha1{{ else }}apps/v1{{ end }}

--- a/standard-app/templates/autoscaling/vpa.yaml
+++ b/standard-app/templates/autoscaling/vpa.yaml
@@ -10,7 +10,8 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ $appName }}
-  {{- include "standard-app.labels" $appValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   targetRef:
     apiVersion: {{ if $appConfig.rollout }}argoproj.io/v1alpha1{{ else }}apps/v1{{ end }}

--- a/standard-app/templates/network/ingress.yaml
+++ b/standard-app/templates/network/ingress.yaml
@@ -66,21 +66,22 @@ spec:
       "component" $ingName
       "Values"    $.Values
       "Release"   $.Release
-      "labels"    (merge 
-                    (default (dict) $.Values.labels)
-                    (default (dict) $ingConfig.labels)
-                  )
+      "labels"    (default (dict) $.Values.labels)
     }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $ingName }}
   namespace: {{ $.Release.Namespace }}
-  {{- include "standard-app.labels" $ingValues | nindent 2 }}
-{{- with $ingConfig.annotations }}
+  labels:
+    {{- include "standard-app.labels" $ingValues | nindent 2 }}
+    {{- with $ingConfig.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $ingConfig.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with $ingConfig.ingressClass }}
   ingressClassName: {{ $ingConfig.ingressClass }}

--- a/standard-app/templates/network/service.yaml
+++ b/standard-app/templates/network/service.yaml
@@ -14,7 +14,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ if .fullname }}{{ .fullname }}{{ else }}{{ $appName }}-{{ .name }}{{ end }}
-  {{- include "standard-app.labels" $appValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $appValues | nindent 2 }}
   {{- with $appConfig.serviceAnnotations }}
   annotations:
   {{ toYaml . | indent 2 }}
@@ -36,7 +37,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $appName }}-canary
-  {{- include "standard-app.labels" $appValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $appValues | nindent 2 }}
   {{- with $appConfig.serviceAnnotations }}
   annotations:
   {{ toYaml . | indent 2 }}

--- a/standard-app/templates/network/servicemonitor.yaml
+++ b/standard-app/templates/network/servicemonitor.yaml
@@ -17,7 +17,7 @@ spec:
     scrapeTimeout: {{ .scrapeTimeout | default "30s"}}
   namespaceSelector:
     matchNames:
-      - {{ .namespace | default $appName }}
+      - {{ .namespace | default $.Release.Namespace }}
   selector:
     matchLabels:
       app: {{ $appName }}

--- a/standard-app/templates/pdb.yaml
+++ b/standard-app/templates/pdb.yaml
@@ -11,7 +11,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $appName }}
-  {{- include "standard-app.labels" $appValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $appValues | nindent 2 }}
 spec:
   minAvailable: {{ $appConfig.pdb.minAvailable }}
   selector:

--- a/standard-app/templates/workloads/cronjob.yaml
+++ b/standard-app/templates/workloads/cronjob.yaml
@@ -4,12 +4,16 @@
       "Values"    $.Values
       "Release"   $.Release
       "labels"    (default (dict) $.Values.labels)
-    }}
+    -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ $cronjobName }}
-  {{- include "standard-app.labels" $cronjobValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $cronjobValues | nindent 2 }}
+    {{- with $cronjobConfig.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   schedule: {{ $cronjobConfig.schedule | quote }}
   suspend: {{ $cronjobConfig.suspend | default "false" }}
@@ -17,12 +21,20 @@ spec:
   jobTemplate:
     metadata:
       name: {{ $cronjobName }}
-      {{- include "standard-app.labels" $cronjobValues | nindent 6 }}
+      labels:
+        {{- include "standard-app.labels" $cronjobValues | nindent 6 }}
+        {{- with $cronjobConfig.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       backoffLimit: {{ $cronjobConfig.backoffLimit | default "0" }}
       template:
         metadata:
-          {{- include "standard-app.labels" $cronjobValues | nindent 10 }}
+          labels:
+            {{- include "standard-app.labels" $cronjobValues | nindent 10 }}
+            {{- with $cronjobConfig.labels }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           {{- if or $cronjobConfig.affinity $.Values.preferSpot }}
           affinity:

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -4,12 +4,16 @@
       "Values"    $.Values
       "Release"   $.Release
       "labels"    (default (dict) $.Values.labels)
-    }}
+    -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $appName }}
-  {{- include "standard-app.labels" $appValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $appValues | nindent 2 }}
+    {{- with $appConfig.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not $appConfig.hpa }}
   replicas: {{ $appConfig.replicas }}
@@ -24,15 +28,18 @@ spec:
       app: {{ $appName }}
   template:
     metadata:
-      {{- include "standard-app.labels" $appValues | nindent 6 }}
+      labels:
+        {{- include "standard-app.labels" $appValues | nindent 6 }}
+        {{- with $appConfig.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- if $appConfig.podAnnotations }}
         {{- toYaml $appConfig.podAnnotations | nindent 8 }}
         {{- end }}
         {{- if $appConfig.secrets }}
         secret.reloader.stakater.com/reload: {{ $appName }}
-        {{- end }}
-        {{- if $.Values.secrets }}
+        {{- else if $.Values.secrets }}
         secret.reloader.stakater.com/reload: {{ $.Release.Name }}
         {{- end }}
     spec:

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -37,11 +37,7 @@ spec:
         {{- if $appConfig.podAnnotations }}
         {{- toYaml $appConfig.podAnnotations | nindent 8 }}
         {{- end }}
-        {{- if $appConfig.secrets }}
-        secret.reloader.stakater.com/reload: {{ $appName }}
-        {{- else if $.Values.secrets }}
-        secret.reloader.stakater.com/reload: {{ $.Release.Name }}
-        {{- end }}
+        reloader.stakater.com/auto: "true"
     spec:
       {{- if or $appConfig.affinity $.Values.preferSpot }}
       affinity:

--- a/standard-app/templates/workloads/job.yaml
+++ b/standard-app/templates/workloads/job.yaml
@@ -17,11 +17,19 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- include "standard-app.labels" $jobValues | nindent 2 }}
+  labels:
+    {{- include "standard-app.labels" $jobValues | nindent 2 }}
+    {{- with $jobConfig.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   template:
     metadata:
-      {{- include "standard-app.labels" $jobValues | nindent 6 }}
+      labels:
+        {{- include "standard-app.labels" $jobValues | nindent 6 }}
+        {{- with $jobConfig.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if or $jobConfig.affinity $.Values.preferSpot }}
       affinity:


### PR DESCRIPTION
refactors the label template to allow resources to have app specific labels alongside global labels. 
earlier versions have a bug where:
    - labels specific to apps are ignored
    - using `merge` for labels in  `label.tpl` results in app/ingress specific labels are incorrectly applied across separate apps
    
side fixes: 
- correct default value for namespace selector for service monitor
- fix duplicate `secret.reloader.stakater.com/reload` annotations