### PR TITLE
feat: HTTPRoute gateway shorthand and middlewares support

### DIFF
--- a/standard-app/CHANGELOG.md
+++ b/standard-app/CHANGELOG.md
@@ -1,2 +1,8 @@
+# 1.9.0
+* HTTPRoute: Add `gateway` field (`internal`|`external`) to replace verbose `parentRefs` blocks. Defaults to `internal` (traefik-internal-gateway). Explicit `parentRefs` still takes precedence for full customization.
+* HTTPRoute: Add `middlewares` list to auto-generate Traefik ExtensionRef filters per rule, replacing repetitive filter blocks in values files.
+* HTTPRoute: Add optional `sectionName` field (defaults to `https`) to customize the gateway listener referenced by the route.
+* Add `traefikMiddlewares` template to create Traefik Middleware CRDs directly from values (similar to `snippetsFilters` for nginx).
+
 # 0.3.0
 * implemented services, ports, readiness probe, volume mounts and resources configuration support at the container level in deployments

--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.8.0
+version: 1.9.0
 maintainers:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -168,6 +168,43 @@ httpRoutes:
           - name: api-legacy-service
             port: 80
 
+  # Full parentRefs override with middlewares
+  legacy-api-route-with-cors:
+    parentRefs:                          # Explicit parentRefs takes precedence over `gateway` field
+      - name: nginx-gateway
+        namespace: nginx-gateway-fabric
+        sectionName: https
+    middlewares:          # Each entry generates an ExtensionRef filter for traefik.io/Middleware
+      - cors-default
+      - body-50m
+    hostnames:
+      - api-legacy.example.com
+    rules:
+      - backendRefs:
+          - name: api-legacy-service
+            port: 80
+
+  # Full parentRefs override with middlewares and custom filters
+  legacy-api-route-with-custom-filters:
+    parentRefs:                          # Explicit parentRefs takes precedence over `gateway` field
+      - name: nginx-gateway
+        namespace: nginx-gateway-fabric
+        sectionName: https
+    middlewares:
+      - cors-default
+    hostnames:
+      - api-legacy.example.com
+    rules:
+      - filters:                        # Additional per-rule filters (appended after middleware filters)
+          - type: ExtensionRef
+            extensionRef:
+              group: gateway.nginx.org
+              kind: SnippetsFilter
+              name: whitelist-vpn
+        backendRefs:
+          - name: api-legacy-service
+            port: 80
+
 # Define Infrastructure Gateways (Only if you need a NEW one)
 gateways:
   # This creates a dedicated GKE Infrastructure Gateway

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -124,6 +124,17 @@ httpRoutes:
           - name: web-service
             port: 8000
 
+  # Route with custom sectionName (defaults to "https" if omitted)
+  http-challenge-route:
+    gateway: external
+    sectionName: http01  # Overrides the default "https" sectionName on the parentRef
+    hostnames:
+      - challenge.dev.example.com
+    rules:
+      - backendRefs:
+          - name: challenge-service
+            port: 80
+
   # Route with middlewares shorthand (auto-generates Traefik ExtensionRef filters on all rules)
   api-with-cors:
     gateway: external

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -105,21 +105,47 @@ snippetsFilters:
 
 # Define Routes (The main configuration)
 httpRoutes:
-  # Connects to your SHARED NGINX Gateway (Cross-namespace)
+  # Simple internal route (default gateway: traefik-internal-gateway)
   api-route:
-    parentRefs:
-      - name: nginx-gateway
-        namespace: nginx-gateway-fabric # <--- Pointing to the existing NGF
-        sectionName: https              # <--- Specific listener
     hostnames:
       - api.dev.example.com
     rules:
-      - matches:
-          - path:
-              type: PathPrefix
-              value: /
-        # Attach the Snippet Filter here!
-        filters:
+      - backendRefs:
+          - name: api-service
+            port: 80
+
+  # External route using the `gateway` shorthand
+  web-route:
+    gateway: external  # Uses traefik-gateway (external). Omit or set "internal" for traefik-internal-gateway.
+    hostnames:
+      - web.dev.example.com
+    rules:
+      - backendRefs:
+          - name: web-service
+            port: 8000
+
+  # Route with middlewares shorthand (auto-generates Traefik ExtensionRef filters on all rules)
+  api-with-cors:
+    gateway: external
+    middlewares:          # Each entry generates an ExtensionRef filter for traefik.io/Middleware
+      - cors-default
+      - body-50m
+    hostnames:
+      - api.dev.example.com
+    rules:
+      - backendRefs:
+          - name: api-service
+            port: 80
+
+  # Route with custom filters (middlewares + per-rule filters can coexist)
+  api-with-custom-filters:
+    gateway: external
+    middlewares:
+      - cors-default
+    hostnames:
+      - api.dev.example.com
+    rules:
+      - filters:                        # Additional per-rule filters (appended after middleware filters)
           - type: ExtensionRef
             extensionRef:
               group: gateway.nginx.org
@@ -129,10 +155,12 @@ httpRoutes:
           - name: api-service
             port: 80
 
-  # Connects to a DEDICATED Gateway (defined below)
+  # Full parentRefs override (for non-Traefik gateways or custom configurations)
   legacy-api-route:
-    parentRefs:
-      - name: legacy-api-gateway # Points to the one created below
+    parentRefs:                          # Explicit parentRefs takes precedence over `gateway` field
+      - name: nginx-gateway
+        namespace: nginx-gateway-fabric
+        sectionName: https
     hostnames:
       - api-legacy.example.com
     rules:

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -95,6 +95,42 @@ serviceAccounts:
     annotations:
       iam.gke.io/gcp-service-account: GOOGLE_SERVICE_ACCOUNT_NAME@PROJECT_ID.iam.gserviceaccount.com
 
+# Define Traefik Middlewares (Optional)
+traefikMiddlewares:
+  cors-default:
+    spec:
+      headers:
+        accessControlAllowOriginList:
+          - "https://app.dev.example.com"
+          - "https://admin.dev.example.com"
+        accessControlAllowMethods:
+          - PUT
+          - GET
+          - POST
+          - DELETE
+        accessControlAllowHeaders:
+          - Authorization
+          - Content-Type
+        accessControlAllowCredentials: true
+        accessControlMaxAge: 300
+  body-50m:
+    spec:
+      buffering:
+        maxRequestBodyBytes: 52428800
+        memRequestBodyBytes: 52428800
+  rate-limit:
+    spec:
+      rateLimit:
+        average: 100
+        burst: 200
+        period: 1m
+  whitelist-ip:
+    spec:
+      ipAllowList:
+        sourceRange:
+          - "10.0.0.0/8"
+          - "88.202.105.66/32"
+
 # Define Snippets for Nginx-gateway-fabric (Optional)
 snippetsFilters:
   whitelist-vpn:
@@ -141,6 +177,20 @@ httpRoutes:
     middlewares:          # Each entry generates an ExtensionRef filter for traefik.io/Middleware
       - cors-default
       - body-50m
+    hostnames:
+      - api.dev.example.com
+    rules:
+      - backendRefs:
+          - name: api-service
+            port: 80
+
+  # Route with multiple middlewares including rate-limit and whitelist-ip
+  api-with-rate-limit:
+    gateway: external
+    middlewares:
+      - cors-default
+      - rate-limit
+      - whitelist-ip
     hostnames:
       - api.dev.example.com
     rules:

--- a/standard-app/templates/network/http-routes.yaml
+++ b/standard-app/templates/network/http-routes.yaml
@@ -20,11 +20,11 @@ spec:
     {{- else if eq (default "internal" $route.gateway) "external" }}
     - name: traefik-gateway
       namespace: traefik-system
-      sectionName: https
+      sectionName: {{ default "https" $route.sectionName }}
     {{- else }}
     - name: traefik-internal-gateway
       namespace: traefik-system
-      sectionName: https
+      sectionName: {{ default "https" $route.sectionName }}
     {{- end }}
   hostnames:
     {{- toYaml $route.hostnames | nindent 4 }}

--- a/standard-app/templates/network/http-routes.yaml
+++ b/standard-app/templates/network/http-routes.yaml
@@ -15,10 +15,42 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if $route.parentRefs }}
     {{- toYaml $route.parentRefs | nindent 4 }}
+    {{- else if eq (default "internal" $route.gateway) "external" }}
+    - name: traefik-gateway
+      namespace: traefik-system
+      sectionName: https
+    {{- else }}
+    - name: traefik-internal-gateway
+      namespace: traefik-system
+      sectionName: https
+    {{- end }}
   hostnames:
     {{- toYaml $route.hostnames | nindent 4 }}
   rules:
+    {{- if $route.middlewares }}
+    {{- range $rule := $route.rules }}
+    - filters:
+        {{- range $mw := $route.middlewares }}
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: {{ $mw }}
+        {{- end }}
+        {{- with $rule.filters }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      backendRefs:
+        {{- toYaml $rule.backendRefs | nindent 8 }}
+      {{- with $rule.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- else }}
     {{- toYaml $route.rules | nindent 4 }}
+    {{- end }}
 ---
 {{- end }}

--- a/standard-app/templates/network/traefik-middlewares.yaml
+++ b/standard-app/templates/network/traefik-middlewares.yaml
@@ -1,0 +1,12 @@
+{{- range $name, $mw := .Values.traefikMiddlewares }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}
+spec:
+  {{- toYaml $mw.spec | nindent 2 }}
+---
+{{- end }}


### PR DESCRIPTION
# 1.9.0
* HTTPRoute: Add `gateway` field (`internal`|`external`) to replace verbose `parentRefs` blocks. Defaults to `internal` (traefik-internal-gateway). Explicit `parentRefs` still takes precedence for full customization.
* HTTPRoute: Add `middlewares` list to auto-generate Traefik ExtensionRef filters per rule, replacing repetitive filter blocks in values files.