### PR TITLE
feat Add referenceGrants for Httproute cross NS reference

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.9.0
+version: 1.9.1
 maintainers:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -266,6 +266,12 @@ httpRoutes:
           - name: api-legacy-service
             port: 80
 
+# Define ReferenceGrant used to enable cross namespace references within Gateway API.
+referenceGrants:
+  # List of namespaces that can reference the services in this namespace from their HTTPRoutes
+  - other-namespace-1
+  - other-namespace-2
+
 # Define Infrastructure Gateways (Only if you need a NEW one)
 gateways:
   # This creates a dedicated GKE Infrastructure Gateway

--- a/standard-app/templates/network/reference-grant.yaml
+++ b/standard-app/templates/network/reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: bar
+  namespace: bar
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: foo
+  to:
+  - group: ""
+    kind: Service

--- a/standard-app/templates/network/reference-grant.yaml
+++ b/standard-app/templates/network/reference-grant.yaml
@@ -1,13 +1,15 @@
+{{- range $borrowerNamespace := .Values.referenceGrants }}
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: bar
-  namespace: bar
+  name: {{ $.Release.Namespace }}-svc-RG-{{ $borrowerNamespace }}
 spec:
   from:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
-    namespace: foo
+    namespace: {{ $borrowerNamespace }}
   to:
   - group: ""
     kind: Service
+---
+{{- end }}


### PR DESCRIPTION
This PR:
- Adds ReferenceGrant support to Gateway API in standard-app to reference cross-NS services. 
https://gateway-api.sigs.k8s.io/api-types/referencegrant/