### PR TITLE
fix: ReferenceGrant should name sould be lower case

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.9.1
+version: 1.9.2
 maintainers:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/templates/network/reference-grant.yaml
+++ b/standard-app/templates/network/reference-grant.yaml
@@ -2,7 +2,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: {{ $.Release.Namespace }}-svc-RG-{{ $borrowerNamespace }}
+  name: {{ $.Release.Namespace }}-svc-rg-{{ $borrowerNamespace }}
 spec:
   from:
   - group: gateway.networking.k8s.io


### PR DESCRIPTION
Error example:
```
ReferenceGrant.gateway.networking.k8s.io "conversational-agent-svc-RG-services-api" is invalid: metadata.name: Invalid value: "conversational-agent-svc-RG-services-api": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```