### PR TITLE
Improve envs & secrets handling

### DIFF
--- a/standard-app/Chart.yaml
+++ b/standard-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: standard-app
 description: A Helm chart library by Cloudkite
 type: application
-version: 1.9.3
+version: 1.9.4
 maintainers:
   - email: hello@cloudkite.io
     name: cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -308,6 +308,7 @@ apps:
   #     * app/deployment and container/initcontainer (env, secrets, service, redinessProbe, resources)
   example-app-1:
     strategyType: RollingUpdate # Recreate or RollingUpdate
+    # secretName: myapp # Override the app secret name(both the external secret and the target secret)
     initContainers:
       exampleinitcontainer-1:
         image: google/cloud-sdk

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -308,7 +308,6 @@ apps:
   #     * app/deployment and container/initcontainer (env, secrets, service, redinessProbe, resources)
   example-app-1:
     strategyType: RollingUpdate # Recreate or RollingUpdate
-    # secretName: myapp # Override the app secret name(both the external secret and the target secret)
     initContainers:
       exampleinitcontainer-1:
         image: google/cloud-sdk
@@ -682,6 +681,7 @@ externalSecret:
   secretStoreName: example-name
   type: aws
   refreshInterval: 1m
+  # secretName: example-name # Override the global secret name(both the external secret and the target secret)
   annotations:
     "argocd.argoproj.io/sync-wave": "-1"
   # secretPath: example-path

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -496,6 +496,7 @@ apps:
     # Single structure for containers
     containers:
       container1:
+        # omitParentSecrets: true # set to true to only configure container secrets in the envfrom block for a container
         # Container-level security context
         securityContext:
           allowPrivilegeEscalation: false
@@ -849,7 +850,6 @@ cronjobs:
           dataFrom:
             - data-from-secret-1
             - data/from/secret/two
-
       exampleinitcontainer-2:
         image: asdasd
         args:
@@ -858,7 +858,6 @@ cronjobs:
           - -r
           - gs://cloudkite-bucket/path
           - /db-backups/
-
     containers:
       examplecontainer:
         image: us-central1-docker.pkg.dev/cloudkite-infra-ops/cloudkite-docker-images/cloudkite

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -87,6 +87,13 @@ env:
   GLOBAL_ENV1: value1
   GLOBAL_ENV2: value2
 
+# inject global additional envs not typically covered under env block
+# otherenv:
+#   - name: ZONE
+#     valueFrom:
+#       fieldRef:
+#         fieldPath: metadata.annotations['topology.kubernetes.io/zone']
+
 # inject global additional envs from any other source using envfrom
 # otherenvFrom:
 #   - secretRef:

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -87,6 +87,11 @@ env:
   GLOBAL_ENV1: value1
   GLOBAL_ENV2: value2
 
+# inject global additional envs from any other source using envfrom
+# otherenvFrom:
+#   - secretRef:
+#       name: example-name
+
 serviceAccounts:
   app-1:
     annotations:
@@ -366,6 +371,10 @@ apps:
         env:
           CONTAINER_ENV1: asd
           CONTAINER_ENV2: qwe
+        # inject container-level additional envs from any other source using envfrom
+        # otherenvFrom:
+        #   - secretRef:
+        #       name: example-name
         lifecycle:
           preStop:
             exec:
@@ -598,6 +607,13 @@ apps:
 
   example-app-3:
     serviceAccount: cloudkite
+    replicas: 1
+    # inject app level additional envs from any other source using envfrom
+    # otherenvFrom:
+    #   - secretRef:
+    #       name: example-name
+    #   - configMapRef:
+    #       name: example-name
     vpa:
       mode: Auto
     volumes:

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -730,6 +730,10 @@ secrets:
   # - secretKey: DB_PASSWORD
   #   key: "my-app-secrets/database"  # Full AWS Secrets Manager key path
   #   property: password
+  # For non key value secrets (e.g ssh keys, txt/json/toml files etc), only works for AWS for now
+  # - secretKey: PRIVATE_KEY
+  #   key: app/private_key
+  #   isNotKeyValue: true
   # Azure Example
   # Serilog__WriteTo__0__Args__connectionString: SERILOG_CONNECTION_STRING
   # TokenConfig__Secret: TOKEN_CONFIG_SECRET
@@ -816,6 +820,8 @@ jobs:
 cronjobs:
   cronjobexample-1:
     schedule: 0 6 * * *
+    image: images/cronjobexample-2
+    tag: dev
     labels:
       cronjobexample-1_label1: value1
       cronjobexample-1_label2: value2

--- a/standard-app/example.values.yaml
+++ b/standard-app/example.values.yaml
@@ -499,6 +499,7 @@ apps:
       runAsGroup: 3000
 
   example-app-1a:
+    replicas: 1
     labels:
       example-app-1a_label1: thisvalue
       example-app-1a_label2: thatvalue
@@ -536,6 +537,7 @@ apps:
 
   example-app-2:
     serviceAccount: cloudkite
+    replicas: 1
     vpa:
       mode: Auto
       ## You can specify resources gap for VPA

--- a/standard-app/templates/autoscaling/hpa.yaml
+++ b/standard-app/templates/autoscaling/hpa.yaml
@@ -5,7 +5,7 @@
       "Release"   $.Release
       "labels"    (default (dict) $.Values.labels)
     -}}
-{{- if $appConfig.hpa }}
+{{- if and ($appConfig.hpa) (not $appConfig.keda) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/standard-app/templates/configs/_externalsecret.tpl
+++ b/standard-app/templates/configs/_externalsecret.tpl
@@ -62,7 +62,9 @@ spec:
         decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- else if eq $type "aws" }}
         key: {{ if $secret.key }}{{ $secret.key }}{{ else }}{{ ternary (print $secretPath "/" $.Release.Name) $.Release.Name (hasKey $.Values.externalSecret "secretPath") }}{{ end }}
+        {{- if not $secret.isNotKeyValue }}
         property: {{ $secret.property | default $secret.secretKey }}
+        {{- end }}
         conversionStrategy: {{ $secret.conversionStrategy | default "Default" }}
         decodingStrategy: {{ $secret.decodingStrategy | default "None" }}
         {{- else }}

--- a/standard-app/templates/configs/configmap.yaml
+++ b/standard-app/templates/configs/configmap.yaml
@@ -10,7 +10,11 @@
     {{- range $appConfig.volumes }}
       {{- if (hasKey . "type") }}
         {{- if .type.configMap }}
-          {{- include "standard-app.configMap" (dict "name" $appName "namespace" $.Release.Namespace "data" .configMapData) }}
+          {{- include "standard-app.configMap" (dict 
+            "name" $appName 
+            "namespace" $.Release.Namespace 
+            "data" .configMapData
+          ) }}
 ---
         {{- end }}
       {{- end }}
@@ -24,7 +28,11 @@
     {{- range $cronjobConfig.volumes }}
       {{- if (hasKey . "type") }}
         {{- if .type.configMap }}
-          {{- include "standard-app.configMap" (dict "name" .type.configMap.name "namespace" $.Release.Namespace "data" .configMapData) }}
+          {{- include "standard-app.configMap" (dict 
+            "name" .type.configMap.name 
+            "namespace" $.Release.Namespace 
+            "data" .configMapData
+          ) }}
 ---
         {{- end }}
       {{- end }}
@@ -38,7 +46,11 @@
     {{- range $jobConfig.volumes }}
       {{- if (hasKey . "type") }}
         {{- if .type.configMap }}
-          {{- include "standard-app.configMap" (dict "name" .type.configMap.name "namespace" $.Release.Namespace "data" .configMapData) }}
+          {{- include "standard-app.configMap" (dict 
+            "name" .type.configMap.name 
+            "namespace" $.Release.Namespace 
+            "data" .configMapData
+          ) }}
 ---
         {{- end }}
       {{- end }}

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -6,12 +6,13 @@
 {{- $secretPath := .Values.externalSecret.secretPath }}
 {{- $refreshInterval := .Values.externalSecret.refreshInterval | default "1m" }}
 
-# Deployment secrets
+# Apps(Deployments)
 {{- range $appName, $appConfig := .Values.apps }}
 
   {{- range $containerType := list "containers" "initContainers" }}
     {{- range $name, $config := index $appConfig $containerType }}
       {{- if $config.secrets }}
+## App Container secret
         {{- template "standard-app.externalSecret" (dict
             "apiVersion" $apiVersion
             "name" $name
@@ -31,9 +32,12 @@
   {{- end }}
 
   {{- if $appConfig.secrets }}
+    {{- /* Determine the name: use secretName if it exists, otherwise fall back to appName */ -}}
+    {{- $effectiveName := $appConfig.secretName | default $appName -}}
+    ## App secret
     {{- template "standard-app.externalSecret" (dict
         "apiVersion" $apiVersion
-        "name" $appName
+        "name" $effectiveName
         "labels" (merge (dict "app" $appName "product" $.Release.Name) (default dict $.Values.labels))
         "annotations" $annotations
         "secrets" $appConfig.secrets
@@ -52,6 +56,7 @@
 # Jobs
 {{- range $jobName, $jobConfig := .Values.jobs }}
   {{- if $jobConfig.secrets }}
+    ## Job secret
     {{- template "standard-app.externalSecret" (dict
         "apiVersion" $apiVersion
         "name" $jobName
@@ -71,9 +76,11 @@
 
 # CronJobs
 {{- range $cronjobName, $cronjobConfig := .Values.cronjobs }}
+
   {{- range $containerType := list "containers" "initContainers" }}
     {{- range $name, $config := index $cronjobConfig $containerType }}
       {{- if $config.secrets }}
+## CronJob Container secret
         {{- template "standard-app.externalSecret" (dict
             "apiVersion" $apiVersion
             "name" $name
@@ -93,6 +100,7 @@
   {{- end }}
 
   {{- if $cronjobConfig.secrets }}
+    ## Cronjob secret
     {{- template "standard-app.externalSecret" (dict
         "apiVersion" $apiVersion
         "name" $cronjobName

--- a/standard-app/templates/configs/externalsecret.yaml
+++ b/standard-app/templates/configs/externalsecret.yaml
@@ -32,12 +32,10 @@
   {{- end }}
 
   {{- if $appConfig.secrets }}
-    {{- /* Determine the name: use secretName if it exists, otherwise fall back to appName */ -}}
-    {{- $effectiveName := $appConfig.secretName | default $appName -}}
     ## App secret
     {{- template "standard-app.externalSecret" (dict
         "apiVersion" $apiVersion
-        "name" $effectiveName
+        "name" $appName
         "labels" (merge (dict "app" $appName "product" $.Release.Name) (default dict $.Values.labels))
         "annotations" $annotations
         "secrets" $appConfig.secrets
@@ -121,9 +119,11 @@
 
 # Global secret
 {{- if .Values.secrets }}
+  {{- /* Determine the name: use externalSecret.secretName if it exists, otherwise fall back to $.Release.Name */ -}}
+  {{- $effectiveName := .Values.externalSecret.secretName | default $.Release.Name -}}
   {{- template "standard-app.externalSecret" (dict
       "apiVersion" $apiVersion
-      "name" $.Release.Name
+      "name" $effectiveName
       "labels" (merge (dict "app" $.Release.Name) (default dict $.Values.labels))
       "annotations" $annotations
       "secrets" .Values.secrets

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -82,6 +82,9 @@ Optional dict keys:
     {{- with (index $app "otherenv") }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with (index $global "otherenv") }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   envFrom:
     {{- if hasKey .container "otherenvFrom" }}
       {{- toYaml (index .container "otherenvFrom") | nindent 4 }}

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -79,6 +79,9 @@ Optional dict keys:
     - name: {{ $key }}
       value: {{ $value | quote }}
     {{- end }}
+    {{- if hasKey .container "otherenv" }}
+      {{- toYaml (index .container "otherenv") | nindent 4 }}
+    {{- end }}
     {{- with (index $app "otherenv") }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -84,6 +84,7 @@ Optional dict keys:
     - secretRef:
         name: {{ $name }}
     {{- end }}
+    {{- if not (and (hasKey .container "omitParentSecrets") .container.omitParentSecrets) }}
     {{- if hasKey $app "secrets" }}
     - secretRef:
         name: {{ $appName }}
@@ -91,6 +92,7 @@ Optional dict keys:
     {{- if hasKey $global "secrets" }}
     - secretRef:
         name: {{ $effectiveGlobalSecretName }}
+    {{- end }}
     {{- end }}
   {{- if or (hasKey .container "resources") (hasKey $app "resources") }}
   resources:

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -83,6 +83,15 @@ Optional dict keys:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   envFrom:
+    {{- if hasKey .container "otherenvFrom" }}
+      {{- toYaml (index .container "otherenvFrom") | nindent 4 }}
+    {{- end }}
+    {{- with (index $app "otherenvFrom") }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with (index $global "otherenvFrom") }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if hasKey .container "secrets" }}
     - secretRef:
         name: {{ $name }}

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -4,7 +4,7 @@ falling back to app-level and global values as needed.
 Supports env, envFrom, volumes, probes, resources, securityContext, etc.
 
 Usage:
-  {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $appConfig "appName" $appName "global" $.Values) | nindent 6 }}
+  {{- include "standard-app.container" (dict "name" $containerName "container" $containerConfig "app" $appConfig "appName" $appName "global" $.Values "releaseName" $.Release.Name) | nindent 6 }}
 
 Required dict keys:
 - name            : string - container name
@@ -12,6 +12,7 @@ Required dict keys:
 - app             : dict - app-level config
 - appName         : string - app name for secrets etc
 - global          : dict - global values for fallback
+- releaseName     : string - chart release name
 
 Optional dict keys:
 - isInitContainer : boolean - check true if init container
@@ -21,8 +22,11 @@ Optional dict keys:
 {{- $name := .name -}}
 {{- $app := .app | default dict -}}
 {{- $appName := .appName -}}
+{{- $releaseName := .releaseName -}}
 {{- $global := .global | default dict -}}
 {{- $isInitContainer := .isInitContainer | default false -}}
+{{- $effectiveGlobalSecretName := .global.externalSecret.secretName | default $releaseName -}}
+
 - name: {{ $name }}
   image: "{{ (.container.image | default $app.image | default $global.image) }}:{{ (.container.tag | default $app.tag | default $global.tag) }}"
   imagePullPolicy: "{{ (.container.imagePullPolicy | default $app.imagePullPolicy | default $global.imagePullPolicy) }}"
@@ -86,7 +90,7 @@ Optional dict keys:
     {{- end }}
     {{- if hasKey $global "secrets" }}
     - secretRef:
-        name: {{ .releaseName }}
+        name: {{ $effectiveGlobalSecretName }}
     {{- end }}
   {{- if or (hasKey .container "resources") (hasKey $app "resources") }}
   resources:

--- a/standard-app/templates/workloads/_container.tpl
+++ b/standard-app/templates/workloads/_container.tpl
@@ -25,7 +25,10 @@ Optional dict keys:
 {{- $releaseName := .releaseName -}}
 {{- $global := .global | default dict -}}
 {{- $isInitContainer := .isInitContainer | default false -}}
-{{- $effectiveGlobalSecretName := .global.externalSecret.secretName | default $releaseName -}}
+{{- $effectiveGlobalSecretName := $releaseName -}}
+{{- if and (hasKey .global "externalSecret") (hasKey .global.externalSecret "secretName") -}}
+  {{- $effectiveGlobalSecretName = .global.externalSecret.secretName -}}
+{{- end -}}
 
 - name: {{ $name }}
   image: "{{ (.container.image | default $app.image | default $global.image) }}:{{ (.container.tag | default $app.tag | default $global.tag) }}"

--- a/standard-app/templates/workloads/deployment.yaml
+++ b/standard-app/templates/workloads/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not $appConfig.hpa }}
+  {{- if and (not $appConfig.hpa) (not $appConfig.keda) }}
   replicas: {{ $appConfig.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ $appConfig.revisionHistoryLimit | default 2 }}


### PR DESCRIPTION
- allow setting custom name for global external secret & target k8s secret
- add option to not pass parent secrets to container(if configured, the container will only include secrets specified for that container)
- skip setting up hpa if keda is configured
- allow input for other envs & envFroms aside from the envs list
- allow input of non key value secrets

Update example-values file